### PR TITLE
ASM-2873 RHEL VM does not get network connectivity

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
          ).wait_for_completion
       # No need to reset the VM in case existing and new network count is the same
       # We are just changing the port-group mapping
-      if(power_state == "poweredOn" and (existing_networks || {}).size != (new_networks || {}).size)
+      if(power_state == "poweredOn")
          #need to give vcenter a chance to reconfigure before rebooting
          sleep 15
          @vm.ResetVM_Task.wait_for_completion


### PR DESCRIPTION
Removed the check to avoid rebooting the VM in case of network definition change. In case on new port-group is added or a previous port-group is updated then the VM is rebooted
Without this change the VM do not have the network connectivity