### PR TITLE
Log VM creation errors

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -97,7 +97,6 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
     else
       create_vm
     end
-  ensure
     raise(Puppet::Error, "Unable to create VM: '#{resource[:name]}'") unless vm
   end
 


### PR DESCRIPTION
Spent a long time yesterday trying to figure out why VM creation
was failing because the ensure block was masking any thrown
exceptions.