### PR TITLE
Retry connection to esx host on maint mode

### DIFF
--- a/lib/puppet/provider/esx_maintmode/default.rb
+++ b/lib/puppet/provider/esx_maintmode/default.rb
@@ -33,11 +33,19 @@ Puppet::Type.type(:esx_maintmode).provide(:esx_maintmode, :parent => Puppet::Pro
   end
 
   def exists?
+    tries = 0
     begin
       host.runtime.inMaintenanceMode
     rescue Exception => e
-      fail "Host is not available: -\n #{e.message}"
+      if tries < 12
+        tries += 1
+        sleep 30
+        retry
+      else
+        fail "Host is not available: -\n #{e.message}"
+      end
     end
   end
+
 
 end


### PR DESCRIPTION
Mostly pertains to a firmware update.  Sometimes we are configuring
an esxi host out-of-band.  And this will fail because ESXi isn't up
right after the OOB resources run.  This way we retry the initial
connection