### PR TITLE
ASM-4361 run reconfigure HA task in more cases

### DIFF
--- a/lib/puppet/provider/esx_reconfigureha/default.rb
+++ b/lib/puppet/provider/esx_reconfigureha/default.rb
@@ -10,14 +10,23 @@ Puppet::Type.type(:esx_reconfigureha).provide(:esx_reconfigureha, :parent => Pup
         raise Puppet::Error, "An invalid host name or IP address is entered. Enter the correct host name and IP address."
       else
         Puppet.notice 'Reconfiguring HA Agent'
-        connection_state = ( host.summary.runtime.dasHostState.state || '' )
-        if connection_state == 'fdmUnreachable' || resource[:force]
+        connection_state = host.summary.runtime.dasHostState.state if host.summary.runtime.dasHostState
+        Puppet.debug("HA connection state for #{resource[:host]} is '#{connection_state}'")
+        # The available states can be found here:
+        # https://www.vmware.com/support/developer/converter-sdk/conv51_apireference/vim.cluster.DasFdmAvailabilityState.html
+        #
+        # The states checked below appear to be the only "good" states where HA
+        # is functioning correctly. It is not clear that reconfiguring HA can
+        # fix all of the other states, but there does not appear to be any harm
+        # in running the HA reconfigure task.
+        if !%w(connectedToMaster election master).include?(connection_state) || resource[:force]
+          Puppet.info("Running HA Reconfigure task for #{resource[:host]}")
           task_status = host.ReconfigureHostForDAS_Task!
-          while (task_status.info.state.match(/running|queued/i))
+          while task_status.info.state.match(/running|queued/i)
             sleep(10)
           end
         end
-        Puppet.notice 'Reconfiguing HA Agent completed.'
+        Puppet.notice 'Reconfiguring HA Agent completed.'
       end
     rescue Exception => e
       fail "Unable to perform the operation because the following exception occurred: -\n #{e.message}"


### PR DESCRIPTION
Previous code was only running the reconfigure HA task if the
dasHostState.state was fdmUnreachable. But there appear to be many
other cases where HA is not funcitoning properly, including if
dasHostState itself is nil.