### PR TITLE
ASM-2927: apply the spec to clone vm with the given vm_custom_spec name

### DIFF
--- a/lib/puppet/type/vc_vm.rb
+++ b/lib/puppet/type/vc_vm.rb
@@ -149,6 +149,9 @@ Puppet::Type.newtype(:vc_vm) do
   end
 
   # Guest Customization params
+  newparam(:guest_custom_spec ) do
+    desc 'Name of the guest customization spec to select'
+  end
   newparam(:guest_customization ) do
     desc 'Enable guest customization'
     newvalues(:true, :false)


### PR DESCRIPTION
handles the vm custom spec in the vc_vm provider module; vc_vm type is updated with the new param for the vm custom spec