### PR TITLE
ASM-5147 Unable to clone across clusters under same datacenters.

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -318,10 +318,12 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
     end
 
     datastore = resource[:datastore]
-    if datastore
+    unless datastore
       ds = get_cluster_datastore
       raise(Puppet::Error, "Unable to find the target datastore '#{datastore}'") unless ds
-      spec.datastore = ds
+      spec.datastore = datastore_object(ds)
+    else
+      spec.datastore = datastore_object("[#{datastore}]")
     end
 
     spec
@@ -625,6 +627,10 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
       :name => vm_name,
       :spec => spec
     ).wait_for_completion
+  end
+
+  def datastore_object(datastore_name)
+    cluster.datastore.select { |ds| ds_obj = ds if "[#{ds.name}]" == datastore_name}.flatten.first
   end
 
   private

--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -630,7 +630,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
   end
 
   def datastore_object(datastore_name)
-    cluster.datastore.select { |ds| ds_obj = ds if "[#{ds.name}]" == datastore_name}.flatten.first
+    cluster.datastore.find { |ds| ds_obj = ds if "[#{ds.name}]" == datastore_name}
   end
 
   private


### PR DESCRIPTION
For clone VM scenario, datastore information was not getting passed as a result clusters having non-common datastore was failing. Also clone VM API needs datastore object instead of datastore name.