### PR TITLE
Update default.rb

### DIFF
--- a/lib/puppet/provider/vc_dvswitch/default.rb
+++ b/lib/puppet/provider/vc_dvswitch/default.rb
@@ -238,7 +238,7 @@ Puppet::Type.type(:vc_dvswitch).provide(:vc_dvswitch, :parent => Puppet::Provide
   end
 
   def host_version(host)
-    @host ||= vim.searchIndex.FindByIp(:datacenter => datacenter , :ip => host, :vmSearch => false) or raise(Puppet::Error, "Unable to find the host '#{host}'")
+    @host ||= vim.searchIndex.FindByDnsName(:datacenter => datacenter , :dnsName => host, :vmSearch => false) or raise(Puppet::Error, "Unable to find the host '#{host}'")
     @host.summary.config.product.version
   end
 


### PR DESCRIPTION
Changed the search mechanism for a host to use the DNS name. If an IP address is passed in to get this function to return correctly then the host match in the list in mo_ref_by_name fails. Without this change dvswitch registration to fails because the host moRef cannot be returned.