### PR TITLE
ASM-5518 vCenter discovery script failing when vcenter is having host in disconnected state

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -45,9 +45,12 @@ def collect_inventory(obj, parent=nil)
       #If ComputeResource but not ClusterComputeResource, it is a standalone host
       hash = collect_inventory(obj.host.first)
     when RbVmomi::VIM::HostSystem
-      @host_count += 1
-      hash[:attributes] = collect_host_attributes(obj)
-      (obj.vm + obj.datastore).each{ |vm| hash[:children] << collect_inventory(vm, obj)}
+      # Skip the servers which are not in connected state.
+      if obj.runtime.connectionState == "connected"
+        @host_count += 1
+        hash[:attributes] = collect_host_attributes(obj)
+        (obj.vm + obj.datastore).each{ |vm| hash[:children] << collect_inventory(vm, obj)}
+      end
     when RbVmomi::VIM::VirtualMachine
       @vm_count += 1
       hash[:attributes] = collect_vm_attributes(obj)


### PR DESCRIPTION
Discovery script is failing to collect the network information for disconnected hosts. Skipping discovery for hosts in disconnected state to avoid failures