### PR TITLE
ASM-5561 Server Puppet module changes for Phase 1 vSAN support for RA HCL

### DIFF
--- a/lib/puppet/provider/vc_vsan_disk_initialize/default.rb
+++ b/lib/puppet/provider/vc_vsan_disk_initialize/default.rb
@@ -100,7 +100,10 @@ Puppet::Type.type(:vc_vsan_disk_initialize).provide(:vc_vsan_disk_initialize, :p
     diskspec.creationType = "hybrid"
     diskspec.host = host
     diskm = RbVmomi::VIM::VimClusterVsanVcDiskManagementSystem(hsconn, 'vsan-disk-management-system')
-    task = diskm.InitializeDiskMappings(:spec => diskspec)
+    diskm.InitializeDiskMappings(:spec => diskspec)
+    # disk initialization do not support async operation.
+    # adding delay to avoid multiple init of disk on multiple nodes
+    sleep(15)
   end
 
 


### PR DESCRIPTION
Intermittently it is observed that initialization of VSAN disk is not getting triggered when there are multiple hosts in the VSAN cluster. Introduced a delay of 15 seconds to ensure success of the deployment.