### PR TITLE
ASM-6057 Management VNIC is not getting mapped correctly for VDS deployments

### DIFF
--- a/lib/puppet/provider/iscsi_intiator_binding/default.rb
+++ b/lib/puppet/provider/iscsi_intiator_binding/default.rb
@@ -104,6 +104,7 @@ Puppet::Type.type(:iscsi_intiator_binding).provide(:default, :parent => Puppet::
         if ( binded_vmk_nics_arr.uniq.sort == input_vmk_nics_arr.uniq.sort )
           flag = 0
         else
+          resource[:vmknics] = (input_vmk_nics_arr - binded_vmk_nics_arr).uniq.join(" ")
           flag = 1
         end
       else


### PR DESCRIPTION
iSCSI initiator mapping puppet resource is using esxcli commands for mapping vmkernel with software adapters. In case vmkernel is already binding to the software adapter, error was generated.
so far we were having one to mapping between iSCSI VMK and storage adapter thats why this error was not surfaced

with software initiator we need to map multiple vmkernel to same storage adapter.