### PR TITLE
ASM-5858 VSAN Teardown Work

### DIFF
--- a/lib/puppet/type/esx_maintmode.rb
+++ b/lib/puppet/type/esx_maintmode.rb
@@ -53,4 +53,9 @@ Puppet::Type.newtype(:esx_maintmode) do
       v.inspect
     end
   end
+
+  newparam(:vsan_action) do
+    desc "describe VSAN action needs to be taken"
+    newvalues('ensureObjectAccessibility', 'evacuateAllData', 'noAction')
+  end
 end


### PR DESCRIPTION
VSAN Teardown moves the host to maintenance mode before removing the cluster disk groups. Currently we were not passing the VSAN maintenance behavior explicitly which was initiating the maintenance mode in 'ensureAccessibility". And this process is time-consuming and may result in errors during teardown.

Added "noAction" behavior to make sure VSAN teardown works without any additional validation.