### PR TITLE
ASM-6387 ASM to support Urgent Fury vSAN RA

### DIFF
--- a/lib/puppet/provider/vc_vsan_disk_initialize/default.rb
+++ b/lib/puppet/provider/vc_vsan_disk_initialize/default.rb
@@ -87,6 +87,7 @@ Puppet::Type.type(:vc_vsan_disk_initialize).provide(:vc_vsan_disk_initialize, :p
     vsandisks.each do |vsandisk|
       next if vsandisk.disk.displayName.match(/usb/i)
       next  if vsandisk.state == "inUse"
+      next  if vsandisk.vendor.strip == "ATA"
       if vsandisk.disk.ssd
         ssd.push(vsandisk.disk)
       else


### PR DESCRIPTION
Need to skip internal SATA Disk configured as in AHCI Mode. These disks has to be used for OS installation or left as-is