### PR TITLE
ASM-6570 Task : script in vcenter module to gather ESX software inventory

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -176,6 +176,7 @@ begin
   Timeout.timeout(opts[:timeout]) do
     vim = RbVmomi::VIM.connect(:host=>opts[:server], :password=>opts[:password], :user=> opts[:username], :port=>opts[:port], :insecure=>true)
     facts = collect_vcenter_facts(vim).to_json
+    vim.close if vim # close open connection
   end
 rescue Timeout::Error
   puts "Timed out trying to gather inventory"

--- a/bin/esx_software_discovery.rb
+++ b/bin/esx_software_discovery.rb
@@ -1,0 +1,47 @@
+#!/opt/puppet/bin/ruby
+require 'json'
+require 'rbvmomi'
+require 'trollop'
+
+opts = Trollop::options do
+  opt :server, "ESX address", :type => :string, :required => true
+  opt :port, "ESX port", :default => 443
+  opt :username, "ESX username", :type => :string, :required => true
+  opt :password, "ESX password", :type => :string, :default => ENV["PASSWORD"]
+  opt :timeout, "command timeout", :default => 240
+  opt :output, "output facts to a file", :type => :string, :required => true
+end
+facts = {}
+
+def collect_esx_installed_packages(host)
+  host.esxcli.software.vib.list.map { |o| o.props.reject { |k| k == :dynamicProperty} }
+end
+
+def collect_esx_facts(vim)
+  # Traverse to host object
+  dc = vim.serviceInstance.find_datacenter
+  host = dc.hostFolder.children.first.host.first
+  hash = {:name => host.name, :id => host._ref, :type => host.class}
+  hash[:installed_packages] = collect_esx_installed_packages(host).to_json
+  hash
+end
+
+begin
+  Timeout.timeout(opts[:timeout]) do
+    vim = RbVmomi::VIM.connect(:host=>opts[:server], :password=>opts[:password], :user=> opts[:username], :port=>opts[:port], :insecure=>true)
+    facts = collect_esx_facts(vim).to_json
+    vim.close if vim # close open connection
+
+    if facts.empty?
+      puts "Could not get updated facts"
+      exit 1
+    else
+      puts "Successfully gathered inventory."
+      puts JSON.pretty_generate(JSON.parse(facts))
+      File.write(opts[:output], facts)
+    end
+  end
+rescue Exception => e
+  puts "Error gathering ESX software inventory: #{e.class}:#{e.message}"
+  exit 1
+end


### PR DESCRIPTION
This is first task for gathering VIB inventory for a ESXi host via a new script esx_software_discovery.rb
With relevant PUT device/:cert_name API in asm-deployer, this script will be invoked.

The fields from the inventory for each VIB package include:
AcceptanceLevel, CreationDate, ID, InstallDate, Name, Vendor, Version


