### PR TITLE
ASM-6570: Use reliable method to get all VIBs, with more details

### DIFF
--- a/bin/esx_software_discovery.rb
+++ b/bin/esx_software_discovery.rb
@@ -14,7 +14,7 @@ end
 facts = {}
 
 def collect_esx_installed_packages(host)
-  host.esxcli.software.vib.list.map { |o| o.props.reject { |k| k == :dynamicProperty} }
+  host.esxcli.software.vib.get.map { |o| o.props.reject { |k| k == :dynamicProperty} }
 end
 
 def collect_esx_facts(vim)


### PR DESCRIPTION
Seems esxcli software vib list does not accurately indicate the VIBs, especially when VIBs are removed.
The new method of using esxcli software vib get is more trustworthy.