### PR TITLE
ASM-6707 VSAN settings to support H730 controller

### DIFF
--- a/lib/puppet/provider/esx_advanced_options/default.rb
+++ b/lib/puppet/provider/esx_advanced_options/default.rb
@@ -39,6 +39,7 @@ Puppet::Type.type(:esx_advanced_options).provide(:esx_advanced_options, :parent 
 
   def cast_option(key, value)
     optdef = host.configManager.advancedOption.supportedOption.find{|so| so[:key] == key}
+    return value.to_i if optdef.nil?
     case optdef.optionType.class.to_s
     when "IntOption"
       RbVmomi::BasicTypes::Int.new value.to_i


### PR DESCRIPTION
Additional parameters added for VSAN configuation do not have optionType leading to NillClass error. For parameters where we don't have type. we are using it as integer class which is default type