### PR TITLE
ASM-6833 vCenter discovery can fail for pvlanId inventory

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -161,10 +161,12 @@ def collect_vm_attributes(vm)
 end
 
 def collect_vds_portgroup_attributes(portgroup)
-  attributes = {}
+  return {} unless portgroup.config.defaultPortConfig.vlan.respond_to?(:vlanId)
+
   vlan_id = portgroup.config.defaultPortConfig.vlan.vlanId
-  attributes[:vlan_id] = vlan_id if vlan_id.is_a?(Integer)
-  attributes
+  return {} unless vlan_id.is_a?(Integer)
+
+  {:vlan_id => vlan_id}
 end
 
 begin


### PR DESCRIPTION
collect_vds_portgroup_attributes inspected the
`defaultPortConfig.vlan` for a vlanId but in some cases it is passed a
`VmwareDistributedVirtualSwitchPvlanSpec` that does not have that
method.

Example data:

    [1] pry(main)> portgroup.config.defaultPortConfig.vlan
    => VmwareDistributedVirtualSwitchPvlanSpec(
      dynamicProperty: [],
      inherited: false,
      pvlanId: 20
    )