### PR TITLE
ASM-2266 Storage Cluster with DRS and VM deployment

### DIFF
--- a/lib/puppet/type/vc_storagepod.rb
+++ b/lib/puppet/type/vc_storagepod.rb
@@ -1,4 +1,6 @@
 # Copyright (C) 2013 VMware, Inc.
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:vc_storagepod) do
 
   @doc = "Manage Storage Pods (clusters)"
@@ -9,6 +11,10 @@ Puppet::Type.newtype(:vc_storagepod) do
 
   newparam(:datacenter) do
     desc "Datacenter in which the cluster will be used"
+  end
+
+  newparam(:drs, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc "Configure DRS on storage pod"
   end
 
   ensurable do


### PR DESCRIPTION
* Add param for Storage DRS enablement to storagePod resource.  
* Add ability to create VM on storage cluster.  
  * If no datastore is explicitly supplied, the ordering will use Storage Pod -> Remote Datastore -> Local Datastore (each ordered by available space) for choosing which datastore to deploy the VM to