### PR TITLE
ASM-6587 Workaround NoMethodError in toRbvmomiTypeHash method in rbvmomi

### DIFF
--- a/bin/esx_software_discovery.rb
+++ b/bin/esx_software_discovery.rb
@@ -1,6 +1,7 @@
 #!/opt/puppet/bin/ruby
 require 'json'
 require 'rbvmomi'
+require_relative '../lib/puppet_x/puppetlabs/transport/rbvmomi_patch' # Use patched library to workaround rbvmomi issues
 require 'trollop'
 
 opts = Trollop::options do
@@ -44,6 +45,6 @@ begin
     end
   end
 rescue Exception => e
-  puts "Error gathering ESX software inventory: #{e.class}:#{e.message}"
+  puts "Error gathering ESX software inventory: #{e.class}:#{e.message}\n#{e.backtrace.join("\n")}"
   exit 1
 end

--- a/lib/puppet/provider/esx_software_update/default.rb
+++ b/lib/puppet/provider/esx_software_update/default.rb
@@ -1,6 +1,6 @@
 provider_path = Pathname.new(__FILE__).parent.parent
-require File.join(provider_path, 'vcenter')
 require 'rbvmomi'
+require File.join(provider_path, 'vcenter')
 require 'asm/util'
 
 Puppet::Type.type(:esx_software_update).provide(:esx_software_update, :parent => Puppet::Provider::Vcenter) do
@@ -126,8 +126,9 @@ Puppet::Type.type(:esx_software_update).provide(:esx_software_update, :parent =>
             else
               Puppet.warning("Unexpected VIB source information: #{vib_source_data} is not an Array.")
             end
-          rescue RbVmomi::Fault => e
-            Puppet.error("Failed to get VIB info for #{qualified_vib_path} due to error: #{e.message} #{e.fault.errMsg}")
+          rescue Exception => e
+            Puppet.error("Failed to get VIB info for #{qualified_vib_path} due to error: #{e.message}")
+            Puppet.error("Fault error message: #{e.fault.errMsg}") if e.is_a?(RbVmomi::Fault)
             raise e
           end
         end

--- a/lib/puppet_x/puppetlabs/transport/rbvmomi_patch.rb
+++ b/lib/puppet_x/puppetlabs/transport/rbvmomi_patch.rb
@@ -1,0 +1,50 @@
+# Here we monkey-patch classes to workaround issues in public rbvmomi
+
+RbVmomi::VIM::DynamicTypeMgrManagedTypeInfo.send(:alias_method, :__toRbvmomiTypeHash, :toRbvmomiTypeHash)
+RbVmomi::VIM::DynamicTypeMgrManagedTypeInfo.send(:define_method, :toRbvmomiTypeHash) do
+  {
+    self.wsdlName => {
+      'kind' => 'managed',
+      'type-id' => self.name,
+      'base-type-id' => self.base.first,
+      'props' => self.property.map do |prop|
+        {
+          'name' => prop.name,
+          'type-id-ref' => prop.type.gsub("[]", ""),
+          'is-array' => (prop.type =~ /\[\]$/) ? true : false,
+          'is-optional' => prop.annotation.find{|a| a.name == "optional"} ? true : false,
+          'version-id-ref' => prop.version,
+        }
+      end,
+      'methods' => Hash[
+        self.method.map do |method|
+          result = method.returnTypeInfo
+          unless result
+            puts "#{method.name} does not have a valid return type..."
+          end
+
+          [method.wsdlName,
+           {
+             'params' => method.paramTypeInfo.map do |param|
+               {
+                 'name' => param.name,
+                 'type-id-ref' => param.type.gsub("[]", ""),
+                 'is-array' => (param.type =~ /\[\]$/) ? true : false,
+                 'is-optional' => param.annotation.find{|a| a.name == "optional"} ? true : false,
+                 'version-id-ref' => param.version,
+               }
+             end,
+             'result' => result.nil? ? result : {  # This is the only line we monkey-patch from original implementation
+               'name' => result.name,
+               'type-id-ref' => result.type.gsub("[]", ""),
+               'is-array' => (result.type =~ /\[\]$/) ? true : false,
+               'is-optional' => result.annotation.find{|a| a.name == "optional"} ? true : false,
+               'version-id-ref' => result.version,
+             }
+           }
+          ]
+        end
+      ]
+    }
+  }
+end

--- a/lib/puppet_x/puppetlabs/transport/vsphere.rb
+++ b/lib/puppet_x/puppetlabs/transport/vsphere.rb
@@ -1,5 +1,8 @@
 # Copyright (C) 2013 VMware, Inc.
-require 'rbvmomi' if Puppet.features.vsphere? and ! Puppet.run_mode.master?
+if Puppet.features.vsphere? and ! Puppet.run_mode.master?
+  require 'rbvmomi'
+  require_relative 'rbvmomi_patch' # Use patched library to workaround rbvmomi issues
+end
 
 module PuppetX::Puppetlabs::Transport
   class Vsphere


### PR DESCRIPTION
Seems with ESX 6.0, VMware added some APIs which do not have the returnTypeInfo defined in VMODL:
e.g. WitnessJoinVsanCluster, WitnessSetPreferredFaultDomain, AddUnicastAgentWitness, LeaveVsanCluster, RemoveUnicastAgent

The EsxCliNamespace used by the host object in ESX discovery and software updates ends up invoking RbVmomi::VIM::DynamicTypeMgrManagedTypeInfo.toRbvmomiTypeHash, where it tries to access properties of returnTypeInfo of every VMODL APIs.

As a result, when it encounters any of above mentioned methods, it results into NoMethodError.

To workaround such problem, we monkey-patch the toRbvmomiTypeHash by setting result = nil for such methods without any returnTypeInfo.