### PR TITLE
ASM-6603 Support vSAN read Nodes with FX2 All-flash platforms

### DIFF
--- a/lib/puppet/provider/vc_spbm/default.rb
+++ b/lib/puppet/provider/vc_spbm/default.rb
@@ -72,14 +72,14 @@ Puppet::Type.type(:vc_spbm).provide(:vc_spbm, :parent => Puppet::Provider::Vcent
               found = true
               rules << "VSAN.%s=%s" % [property_instance.id, failure_tolerance_value[resource[:replica_preference]]]
             else
-              rules << "VSAN.%s=%s" % [property_instance.id, property_instance.value]
+              rules << "VSAN.%s=%s" % [property_instance.id, failure_tolerance_value[resource[:replica_preference]]]
             end
           end
         end
       end
     end
 
-    rules << "VSAN.%s=%s" % ["replicaPreference", resource[:replica_preference]] unless found
+    rules << "VSAN.%s=%s" % ["replicaPreference", failure_tolerance_value[resource[:replica_preference]]] unless found
     profile_modify(rules)
     return true
   end

--- a/lib/puppet/provider/vc_vsan_disk_initialize/default.rb
+++ b/lib/puppet/provider/vc_vsan_disk_initialize/default.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:vc_vsan_disk_initialize).provide(:vc_vsan_disk_initialize, :p
         next
       else
         hosts_task_info[host.name] = []
-        Puppet.debug("Initiating disk intialization for #server #{host.name}")
+        Puppet.debug("Initiating disk intialization for server #{host.name}")
         hosts_task_info[host.name] = initialize_disk(host)
       end
     end
@@ -108,7 +108,7 @@ Puppet::Type.type(:vc_vsan_disk_initialize).provide(:vc_vsan_disk_initialize, :p
     return true if ssd.empty?
     diskspec = RbVmomi::VIM::VimVsanHostDiskMappingCreationSpec.new()
 
-    case creation_type(nonssd)
+    case resource[:vsan_disk_group_creation_type]
       when "hybrid"
         diskspec.cacheDisks = ssd
         diskspec.capacityDisks = nonssd

--- a/lib/puppet/type/vc_vsan_disk_initialize.rb
+++ b/lib/puppet/type/vc_vsan_disk_initialize.rb
@@ -15,6 +15,12 @@ Puppet::Type.newtype(:vc_vsan_disk_initialize) do
     desc 'Name of the cluster.'
   end
 
+  newparam(:vsan_disk_group_creation_type) do
+    desc 'VSAN disk group creation type'
+    newvalues('hybrid', 'allFlash')
+    defaultto('hybrid')
+  end
+
   newparam(:cleanup_hosts) do
     desc 'Array of Hosts to be removed from VSAN '
   end


### PR DESCRIPTION
Instead of finding the type of disk-group type based on the NIC, used the user specified value to ensure disk-group type is aligned with ASM user input