### PR TITLE
ASM-6600 [puppet] Redirect vSAN traces to an external datastore

### DIFF
--- a/lib/puppet/type/vc_vsan_disk_initialize.rb
+++ b/lib/puppet/type/vc_vsan_disk_initialize.rb
@@ -25,4 +25,8 @@ Puppet::Type.newtype(:vc_vsan_disk_initialize) do
     desc 'Array of Hosts to be removed from VSAN '
   end
 
+  newparam(:vsan_trace_volume) do
+    desc "Volume name to use for VSAN traces"
+  end
+
 end


### PR DESCRIPTION
As per the story, we need to redirect VSAN traces to external datastore.
In the puppet module, we are passed a volume name to set for all hosts,
and we simply apply that.

The business logic of determining the right volume name is done in
asm-deployer. We set vsan traces to this datastore corresponding to this
volume name using the relevant esxcli API