### PR TITLE
ASM-7146 Fx2 VSAN deployments failed for FC 630

### DIFF
--- a/lib/puppet/provider/vc_vsan/default.rb
+++ b/lib/puppet/provider/vc_vsan/default.rb
@@ -44,12 +44,10 @@ Puppet::Type.type(:vc_vsan).provide(:vc_vsan, :parent => Puppet::Provider::Vcent
 
   def exists?
     if resource[:dedup].nil?
-      vsan_cluster_config.enabled &&
-          vsan_cluster_config.defaultConfig.autoClaimStorage == resource[:auto_claim]
+      vsan_cluster_config.enabled
     else
       vsan_cluster_config.enabled &&
-          vsan_cluster_config.defaultConfig.autoClaimStorage == resource[:auto_claim] &&
-          vsan_cluster_config.dataEfficiencyConfig.dedupEnabled == resource[:dedup]
+        vsan_cluster_config.dataEfficiencyConfig.dedupEnabled.to_s == resource[:dedup].to_s
     end
   end
 


### PR DESCRIPTION
Avoid setting VSAN de-duplication on retry if it is already configured. In case de-dedup is already configured then VSAN raise an exception