### PR TITLE
ASM-2675 Multi VirtualDisk configuration for VM

### DIFF
--- a/lib/puppet/type/vc_vm.rb
+++ b/lib/puppet/type/vc_vm.rb
@@ -261,4 +261,15 @@ Puppet::Type.newtype(:vc_vm) do
     desc 'VM Storage policy name'
   end
 
+  newparam(:virtual_disks) do
+    desc "Multiple storage disks to deploy"
+    munge do |value|
+      if value.is_a?(Hash)
+        [value]
+      else
+        value
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Allow a `virtual_disks` param to be used which contains a list of
disks and their sizes. *order matters*  If the param is used, multiple
storage devices will be created for the virtual machine