### PR TITLE
ASM-7251 Unable to discover vCenter 5.1

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -34,6 +34,10 @@ end
 
 def exiting_profiles(vim)
   profiles = []
+
+  # vCenter 5.1 do not support Profile Based Management
+  return profiles if vim.rev.to_i <= 5.1
+
   require 'rbvmomi/pbm'
   pbm_obj = RbVmomi::PBM
   pbm = pbm_obj.connect(vim, :insecure=> true)


### PR DESCRIPTION
Skip discovery of VSAN Profile Management policy facts listing for vCenter 5.1 as this is not supported for 5.1