### PR TITLE
ASM-7315 VSAN vm's are not getting associated with the ASM storage policy

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -36,7 +36,7 @@ def exiting_profiles(vim)
   profiles = []
 
   # vCenter 5.1 do not support Profile Based Management
-  return profiles if vim.rev.to_f <= 5.1
+  return profiles if Float(vim.rev) <= 5.1
 
   require 'rbvmomi/pbm'
   pbm_obj = RbVmomi::PBM

--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -36,7 +36,7 @@ def exiting_profiles(vim)
   profiles = []
 
   # vCenter 5.1 do not support Profile Based Management
-  return profiles if vim.rev.to_i <= 5.1
+  return profiles if vim.rev.to_f <= 5.1
 
   require 'rbvmomi/pbm'
   pbm_obj = RbVmomi::PBM

--- a/lib/puppet/provider/vc_spbm/default.rb
+++ b/lib/puppet/provider/vc_spbm/default.rb
@@ -1,7 +1,6 @@
 provider_path = Pathname.new(__FILE__).parent.parent
 require File.join(provider_path, 'vcenter')
 require 'rbvmomi'
-require 'pry'
 require File.join(provider_path, 'spbmapiutils')
 
 Puppet::Type.type(:vc_spbm).provide(:vc_spbm, :parent => Puppet::Provider::Vcenter) do

--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -550,7 +550,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
   end
 
   def vsan_data_store?(datastore)
-    datastore.match(/vsanDatastore/)
+    datastore =~ /vsanDatastore/
   end
 
   def storage_placement_spec(datastore, resource_pool)


### PR DESCRIPTION
- Instead of just passing the name, we have to pass profile identification to work consistently.
- Discovery of storage profile was getting skipped with vcenter version 5.5