### PR TITLE
ASM-7475 VSAN Storage policy not attached to VMware Virtual Disk

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -646,11 +646,19 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
       :capacityInKB => size
     )
 
-    RbVmomi::VIM.VirtualDeviceConfigSpec(
-      :device => disk,
-      :fileOperation => RbVmomi::VIM.VirtualDeviceConfigSpecFileOperation('create'),
-      :operation => RbVmomi::VIM.VirtualDeviceConfigSpecOperation('add')
-    )
+    config = {
+        :device => disk,
+        :fileOperation => RbVmomi::VIM.VirtualDeviceConfigSpecFileOperation('create'),
+        :operation => RbVmomi::VIM.VirtualDeviceConfigSpecOperation('add')
+    }
+
+    if vsan_data_store?(file_name) && resource[:vm_storage_policy]
+      config[:profile] = [VIM::VirtualMachineDefinedProfileSpec(
+          :profileId => profile(resource[:vm_storage_policy]).profileId.uniqueId
+      )]
+    end
+
+    RbVmomi::VIM.VirtualDeviceConfigSpec(config)
   end
 
   # get network configuration


### PR DESCRIPTION
For Virtual disk associated with VSAN enabled cluter was not associated with ASM specific storage policy. Update the storage policy to be associated with VM and HDD specifically