### PR TITLE
ASM-7541 ASM default storage policy not overwritten when switched from All flash to Hybrid deployemnts

### DIFF
--- a/lib/puppet/provider/vc_spbm/default.rb
+++ b/lib/puppet/provider/vc_spbm/default.rb
@@ -100,7 +100,7 @@ Puppet::Type.type(:vc_spbm).provide(:vc_spbm, :parent => Puppet::Provider::Vcent
       sub_profile.capability.each do |cap|
         cap.constraint.each do |constraint|
           constraint.propertyInstance.each do |property_instance|
-            if property_instance.id == "replicaPreference" && value != 'none'
+            if property_instance.id == "replicaPreference" && value != "none"
               property_instance.value = failure_tolerance_value[resource[:failure_tolerance_method]]
               found = true
               rules << "VSAN.%s=%s" % [property_instance.id, failure_tolerance_value[resource[:failure_tolerance_method]]]
@@ -112,7 +112,7 @@ Puppet::Type.type(:vc_spbm).provide(:vc_spbm, :parent => Puppet::Provider::Vcent
       end
     end
 
-    if !found && value != 'none'
+    if !found && value != "none"
       rules << "VSAN.%s=%s" % ["replicaPreference", failure_tolerance_value[resource[:failure_tolerance_method]]]
     end
     profile_modify(rules)

--- a/lib/puppet/provider/vc_spbm/default.rb
+++ b/lib/puppet/provider/vc_spbm/default.rb
@@ -100,19 +100,21 @@ Puppet::Type.type(:vc_spbm).provide(:vc_spbm, :parent => Puppet::Provider::Vcent
       sub_profile.capability.each do |cap|
         cap.constraint.each do |constraint|
           constraint.propertyInstance.each do |property_instance|
-            if property_instance.id == "replicaPreference"
+            if property_instance.id == "replicaPreference" && value != 'none'
               property_instance.value = failure_tolerance_value[resource[:failure_tolerance_method]]
               found = true
               rules << "VSAN.%s=%s" % [property_instance.id, failure_tolerance_value[resource[:failure_tolerance_method]]]
             else
-              rules << "VSAN.%s=%s" % [property_instance.id, failure_tolerance_value[resource[:failure_tolerance_method]]]
+              rules << "VSAN.%s=%s" % [property_instance.id, property_instance.value] unless property_instance.id == "replicaPreference"
             end
           end
         end
       end
     end
 
-    rules << "VSAN.%s=%s" % ["replicaPreference", failure_tolerance_value[resource[:failure_tolerance_method]]] unless found
+    if !found && value != 'none'
+      rules << "VSAN.%s=%s" % ["replicaPreference", failure_tolerance_value[resource[:failure_tolerance_method]]]
+    end
     profile_modify(rules)
     return true
   end

--- a/lib/puppet/type/vc_spbm.rb
+++ b/lib/puppet/type/vc_spbm.rb
@@ -17,7 +17,7 @@ Puppet::Type.newtype(:vc_spbm) do
 
   newproperty(:failure_tolerance_method) do
     desc "Replication state"
-    defaultto('none')
+    defaultto("none")
   end
 
   newproperty(:host_failures_to_tolerate) do

--- a/lib/puppet/type/vc_spbm.rb
+++ b/lib/puppet/type/vc_spbm.rb
@@ -17,6 +17,7 @@ Puppet::Type.newtype(:vc_spbm) do
 
   newproperty(:failure_tolerance_method) do
     desc "Replication state"
+    defaultto('none')
   end
 
   newproperty(:host_failures_to_tolerate) do


### PR DESCRIPTION
We were not removing a rules which takes care fault tolerance method. Default value of the rules is set to "none". In case value is not specified from the asm-deployer, we will remove the rule which takes care of fault tolerance method.