### PR TITLE
Add timing information when rebooting host during VIB updates

### DIFF
--- a/lib/puppet/provider/esx_software_update/default.rb
+++ b/lib/puppet/provider/esx_software_update/default.rb
@@ -158,24 +158,29 @@ Puppet::Type.type(:esx_software_update).provide(:esx_software_update, :parent =>
   # Helper method to reboot a ESX host and wait for it to come back upto desired timeout
   def reboot_and_wait_for_host
     host.RebootHost_Task({:force => false}).wait_for_completion
-    Puppet.debug("Waiting upto #{resource[:reboot_timeout]} seconds for host to connect")
+    Puppet.debug("%s Waiting upto %s seconds for host to connect" % [Time.now, resource[:reboot_timeout]])
     rounds = ((1.0 * (resource[:reboot_timeout] - 180)) / 30).ceil
     sleep 180  # Sleep for 3 minutes to allow reboot initiation request to reflect
+    reboot_done = false
     for i in 1..rounds
       begin
         if host.runtime.connectionState == "connected"
-          Puppet.debug("Host has rebooted and is connected")
+          Puppet.info("Host has rebooted and is connected")
+          reboot_done = true
           break
+        else
+          Puppet.debug("%s Host connection state: %s " % [Time.now, host.runtime.connectionState] )
         end
       rescue Exception => ex
-        Puppet.debug("Ignoring #{ex} since host is in process of rebooting")
+        Puppet.debug("Host is in process of rebooting, ignoring error: %s %s" % [ex.class, ex.message])
         if ex.is_a?(RbVmomi::Fault) && ex.fault.class.to_s == "NotAuthenticated"
-          Puppet.debug("Resetting host connection")
+          Puppet.info("Reset host connection")
           reset_connection
         end
       end
       sleep 30
     end
+    Puppet.warning("Host not connected after rebooting in %d seconds" % resource[:reboot_timeout]) unless reboot_done
   end
 
   # Get fully qualified path for a given VIB, performing any setup necessary


### PR DESCRIPTION
Seems there are cases where host reboot may take longer than
anticipated. We need to add information in logs to know how long
it took to connect for debugging purpose. Also we add a log entry if
we find the host reboot timeout happened and we were still not able
to have connected host.