### PR TITLE
ASM-7640 Warning Messages thrown in FC 630 cluster for VSAN

### DIFF
--- a/lib/puppet/provider/vc_vsan_health_performance/default.rb
+++ b/lib/puppet/provider/vc_vsan_health_performance/default.rb
@@ -1,0 +1,44 @@
+provider_path = Pathname.new(__FILE__).parent.parent
+require File.join(provider_path, 'vcenter')
+require 'rbvmomi'
+require File.join(provider_path, 'vsanmgmt.api')
+require File.join(provider_path, 'vsanapiutils')
+
+Puppet::Type.type(:vc_vsan_health_performance).provide(:vc_vsan_health_performance, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Enable / Disable VSAN property."
+
+  def create
+    Puppet.debug("Configuring VSAN performance service")
+    vsan.vsanPerformanceManager.VsanPerfCreateStatsObjectTask(:cluster => cluster).onConnection(vim).wait_for_completion
+  end
+
+  def destroy
+    Puppet.debug("De-Configuring VSAN performance service")
+    vsan.vsanPerformanceManager.VsanPerfDeleteStatsObject(:cluster => cluster)
+  end
+
+  def exists?
+    status = JSON.parse(vsan.vsanClusterHealthSystem.VsanHealthGetClusterStatus(:cluster => cluster))
+    Puppet.debug("VSAN Health Servce Status: #{status}")
+
+    group_health = vsan.vsanPerformanceManager.VsanPerfQueryClusterHealth(:cluster => cluster)[0].groupHealth
+    if resource[:ensure] == :present
+      group_health != "green" ? false : true
+    elsif resource[:ensure] == :absent
+      group_health != "green" ? false : true
+    end
+  end
+
+  def datacenter
+    @dc ||= vim.serviceInstance.find_datacenter(resource[:datacenter])
+  end
+
+  def cluster
+    datacenter.find_compute_resource(resource[:cluster])
+  end
+
+  def vsan
+    @vsan ||= vim.vsan
+  end
+
+end

--- a/lib/puppet/type/vc_vsan_health_performance.rb
+++ b/lib/puppet/type/vc_vsan_health_performance.rb
@@ -1,0 +1,18 @@
+Puppet::Type.newtype(:vc_vsan_health_performance) do
+  @doc = "Enable / Disable Cluster VSAN health performance service."
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "VSAN Resource title"
+  end
+
+  newparam(:cluster) do
+    desc 'Name of the cluster.'
+  end
+
+  newparam(:datacenter) do
+    desc 'Name of the cluster.'
+  end
+
+end

--- a/tests/vc_vsan_health_performance.pp
+++ b/tests/vc_vsan_health_performance.pp
@@ -1,0 +1,17 @@
+import 'data.pp'
+
+transport { 'vcenter':
+  username => $vcenter['username'],
+  password => $vcenter['password'],
+  server   => $vcenter['server'],
+  options  => $vcenter['options'],
+}
+
+# This resource is not ready for testing:
+vc_vsan_health_performance { 'vsan_config':
+  ensure => present,
+  datacenter => $dc1['name'],
+  cluster => $cluster1['name'],
+  transport => Transport['vcenter'],
+}
+


### PR DESCRIPTION
Added support for enabling / disabling VSAN health performance services. By default health services is not enabled when VSAN is enabled on the cluster and due to this, a warning message is shown in VSAN health table