### PR TITLE
ASM-7729 VM clone operation fails when performed across cluster or datacenter with no common datastore

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -771,7 +771,8 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
   end
 
   def datastore_object(datastore_name)
-    cluster.datastore.find { |ds| ds_obj = ds if "[#{ds.name}]" == datastore_name}
+    datastore_name = datastore_name.is_a?(Hash) ? datastore_name["name"] : datastore_name
+    cluster.datastore.find { |ds| ds_obj = ds if "[#{ds.name}]" == datastore_name || ds.name == datastore_name}
   end
 
   private

--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -772,7 +772,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
 
   def datastore_object(datastore_name)
     datastore_name = datastore_name.is_a?(Hash) ? datastore_name["name"] : datastore_name
-    cluster.datastore.find { |ds| ds_obj = ds if "[#{ds.name}]" == datastore_name || ds.name == datastore_name}
+    cluster.datastore.find { |ds| "[#{ds.name}]" == datastore_name || ds.name == datastore_name}
   end
 
   private


### PR DESCRIPTION
For clone operation datatore name is not passed for relocation spec passed to VM clone operation. These changes seems to be got broken due some recent changes while adding virtual disk support.