### PR TITLE
 ASM-7569 Move wait for host connection logic out into a seperate resource

### DIFF
--- a/lib/puppet/provider/esx_connection_wait/default.rb
+++ b/lib/puppet/provider/esx_connection_wait/default.rb
@@ -1,0 +1,17 @@
+provider_path = Pathname.new(__FILE__).parent.parent
+require 'rbvmomi'
+require File.join(provider_path, 'vcenter')
+require 'asm/util'
+
+Puppet::Type.type(:esx_connection_wait).provide(:esx_connection_wait, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Wait for ESX host connection upto specified time-limit"
+
+  def exists?
+    false  # Force create to be invoked, or destroy to be ignored
+  end
+
+  def create
+    wait_for_host(resource[:init_sleep], resource[:max_wait])
+  end
+
+end

--- a/lib/puppet/type/esx_connection_wait.rb
+++ b/lib/puppet/type/esx_connection_wait.rb
@@ -1,0 +1,35 @@
+Puppet::Type.newtype(:esx_connection_wait) do
+  @doc = "Wait for ESX host connection upto specified time-limit"
+
+  ensurable
+
+  newparam(:init_sleep) do
+    desc "Initial window to wait before polling for connection state. Defaults to 180 seconds."
+    newvalues(/\d+/)
+    defaultto(180)
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+  newparam(:max_wait) do
+    desc "Maximum time to wait. Defaults to 600 seconds."
+    newvalues(/\d+/)
+    defaultto(600)
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+  newparam(:host, :namevar => true) do
+    desc "The ESX host"
+    validate do |value|
+      if value.nil? || value.strip.length == 0
+        raise ArgumentError, "Invalid name or IP of the host."
+      end
+    end
+  end
+
+end

--- a/tests/esx_connection_wait.pp
+++ b/tests/esx_connection_wait.pp
@@ -1,0 +1,15 @@
+import 'data.pp'
+
+transport { 'vcenter':
+  username => $vcenter['username'],
+  password => $vcenter['password'],
+  server   => $vcenter['server'],
+  options  => $vcenter['options'],
+}
+
+esx_connection_wait { $esx1['hostname']:
+  ensure      => present,
+  init_sleep  => 300,
+  max_wait    => 600,
+  transport   => Transport['vcenter'],
+}


### PR DESCRIPTION
Move the logic of waiting for host into a utility function in vcenter.rb
so that it can be used by all vmware puppet resources.

We also create a new resource esx_connection_wait that can be used after
kicking of ESX reboot on firmware updates