### PR TITLE
ASM-7754 Reduce timeout on ESX software discovery

### DIFF
--- a/bin/esx_software_discovery.rb
+++ b/bin/esx_software_discovery.rb
@@ -9,7 +9,7 @@ opts = Trollop::options do
   opt :port, "ESX port", :default => 443
   opt :username, "ESX username", :type => :string, :required => true
   opt :password, "ESX password", :type => :string, :default => ENV["PASSWORD"]
-  opt :timeout, "command timeout", :default => 240
+  opt :timeout, "command timeout", :default => 20
   opt :output, "output facts to a file", :type => :string, :required => true
   opt :credential_id, 'dummy value for ASM, not used'
 end


### PR DESCRIPTION
Fetching ESX software components is a quick operation, requiring on an
average of 3 seconds. We reduce the timeout from 240 seconds to 20 seconds
so that servers that have ESX not responding can timeout quicker instead
of looping for long time causing UI timeout wierd issues.

However, this is a short term solution. We noticed that even with 20
second timeout in this script, the expected failure seen by the endpoint
is close to 60 seconds. We need to root cause of this extra latency seen
in asm-deployer.