### PR TITLE
ASM-7760 Fix VIM API issues with esxcli on reconnected host

### DIFF
--- a/lib/puppet_x/puppetlabs/transport/vsphere.rb
+++ b/lib/puppet_x/puppetlabs/transport/vsphere.rb
@@ -36,8 +36,12 @@ module PuppetX::Puppetlabs::Transport
 
     def reconnect
       close
-      @vim = nil
-      connect
+      reconnect_opts = {
+          :host => @options[:host], :port => @options[:port], :user => @options[:user], :password => @options[:password],
+          :insecure => @options[:insecure] || true
+      }
+      Puppet.debug("Reconnecting to %s" % reconnect_opts[:host])
+      @vim = RbVmomi::VIM.connect(reconnect_opts)
     end
   end
 end


### PR DESCRIPTION
When we connect a host first time through vsphere transport, the @options
contain only minimal connection params. Once a connection has been
established, @options gets populated with metadata such as ns, ssl,etc.
On reconnecting a host(in case of reboot scenarios ), these extra
metadata creates a VIM connection that fails for esxcli API operations
with error "Not supported with VC less than 5.0" which seems like a bug
in vSphere web services. We fix this issue in reconnect by creating a
VIM connection with the minimal connection params.