### PR TITLE
ASM-7861  Ensure no VSAN action for maintenance mode during server updates

### DIFF
--- a/lib/puppet/provider/esx_maintmode/default.rb
+++ b/lib/puppet/provider/esx_maintmode/default.rb
@@ -10,6 +10,7 @@ Puppet::Type.type(:esx_maintmode).provide(:esx_maintmode, :parent => Puppet::Pro
       host.EnterMaintenanceMode_Task(:timeout => resource[:timeout],
                                      :evacuatePoweredOffVms => resource[:evacuate_powered_off_vms]).wait_for_completion
     else
+      Puppet.debug("VSAN action specified = %s" % resource[:vsan_action])
       decommissionmode = RbVmomi::VIM::VsanHostDecommissionMode.new
       decommissionmode.objectAction = resource[:vsan_action]
       hostmaintspec = RbVmomi::VIM::HostMaintenanceSpec.new


### PR DESCRIPTION
Seems if we do not have this flag, VSAN hosts can fail to enter maintenance
mode because in absence of VSAN action not supplied then VSAN datastore
integrity and accessibility test takes a lot of time and leads to timeout.

If host is not a VSAN host, this flag will not impact maintenance mode.