### PR TITLE
ASM-8110 Enabled "reduced redundancy" for VSAN cluster while invoking de-duplication for VSAN cluster

### DIFF
--- a/lib/puppet/provider/vc_vsan/default.rb
+++ b/lib/puppet/provider/vc_vsan/default.rb
@@ -26,6 +26,7 @@ Puppet::Type.type(:vc_vsan).provide(:vc_vsan, :parent => Puppet::Provider::Vcent
     reconfig_spec.dataEfficiencyConfig = data_efficiency_spec if resource[:dedup]
     reconfig_spec.vsanClusterConfig = vsan_cluster_config
     reconfig_spec.modify = true
+    reconfig_spec.allowReducedRedundancy = true
 
     vsan_task = vsan.vsanClusterConfigSystem.VsanClusterReconfig(:cluster => cluster, :vsanReconfigSpec => reconfig_spec ).onConnection(vim)
     vsan_task.wait_for_completion


### PR DESCRIPTION
As recommended by VMware team, we have included flag "allowreducedredundancy" for the VSAN cluster while enabling de-duplication. This will help in enabling / disabling redundancy while lesser number of nodes in the VSAN cluster