### PR TITLE
ASM-8111 vCenter inventory fails due to problems getting storage profiles

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -38,7 +38,7 @@ def exiting_profiles(vim)
   # vCenter 5.1 do not support Profile Based Management
   return profiles if Float(vim.rev) <= 5.1
 
-  require 'rbvmomi/pbm'
+  require "rbvmomi/pbm"
   pbm_obj = RbVmomi::PBM
   pbm = pbm_obj.connect(vim, :insecure=> true)
 

--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -38,24 +38,23 @@ def exiting_profiles(vim)
   # vCenter 5.1 do not support Profile Based Management
   return profiles if Float(vim.rev) <= 5.1
 
-  begin
-    require 'rbvmomi/pbm'
-    pbm_obj = RbVmomi::PBM
-    pbm = pbm_obj.connect(vim, :insecure=> true)
+  require 'rbvmomi/pbm'
+  pbm_obj = RbVmomi::PBM
+  pbm = pbm_obj.connect(vim, :insecure=> true)
 
-    pbm_manager = pbm.serviceContent.profileManager
-    profileIds = pbm_manager.PbmQueryProfile(
-        :resourceType => {:resourceType => "STORAGE"},
-        :profileCategory => "REQUIREMENT"
-    )
+  pbm_manager = pbm.serviceContent.profileManager
+  profileIds = pbm_manager.PbmQueryProfile(
+      :resourceType => {:resourceType => "STORAGE"},
+      :profileCategory => "REQUIREMENT"
+  )
 
-    if profileIds.length > 0
-      profiles = pbm_manager.PbmRetrieveContent(:profileIds => profileIds)
-    end
-  rescue
-    STDERR.puts("Failed to look up profiles: %s" % $!.to_s)
+  if profileIds.length > 0
+    profiles = pbm_manager.PbmRetrieveContent(:profileIds => profileIds)
   end
+  profiles
 
+rescue
+  STDERR.puts("Failed to look up profiles: %s" % $!.to_s)
   profiles
 end
 

--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -38,18 +38,22 @@ def exiting_profiles(vim)
   # vCenter 5.1 do not support Profile Based Management
   return profiles if Float(vim.rev) <= 5.1
 
-  require 'rbvmomi/pbm'
-  pbm_obj = RbVmomi::PBM
-  pbm = pbm_obj.connect(vim, :insecure=> true)
+  begin
+    require 'rbvmomi/pbm'
+    pbm_obj = RbVmomi::PBM
+    pbm = pbm_obj.connect(vim, :insecure=> true)
 
-  pbm_manager = pbm.serviceContent.profileManager
-  profileIds = pbm_manager.PbmQueryProfile(
-      :resourceType => {:resourceType => "STORAGE"},
-      :profileCategory => "REQUIREMENT"
-  )
+    pbm_manager = pbm.serviceContent.profileManager
+    profileIds = pbm_manager.PbmQueryProfile(
+        :resourceType => {:resourceType => "STORAGE"},
+        :profileCategory => "REQUIREMENT"
+    )
 
-  if profileIds.length > 0
-    profiles = pbm_manager.PbmRetrieveContent(:profileIds => profileIds)
+    if profileIds.length > 0
+      profiles = pbm_manager.PbmRetrieveContent(:profileIds => profileIds)
+    end
+  rescue
+    STDERR.puts("Failed to look up profiles: %s" % $!.to_s)
   end
 
   profiles


### PR DESCRIPTION
Multiple instances have been observed recently with vCenter 6.0 where storage profile retrieval is failing due to unknown reasons. Support request is sent to VMware team to provide the root case for the same. Rescue block is added to get discovery going will we get the resolution / root cause of the problem