### PR TITLE
ASM-8072 Increase vcenter discovery timeout to 15 minutes

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -8,7 +8,7 @@ opts = Trollop::options do
   opt :port, 'vcenter port', :default => 443
   opt :username, 'vcenter username', :type => :string, :required => true
   opt :password, 'vcenter password', :type => :string, :default => ENV['PASSWORD']
-  opt :timeout, 'command timeout', :default => 240
+  opt :timeout, 'command timeout', :default => 900
   opt :community_string, 'dummy value for ASM, not used'
   opt :credential_id, 'dummy value for ASM, not used'
   opt :output, 'output facts to a file', :type => :string, :required => true


### PR DESCRIPTION
In scenarios with large vCenters (~30 hosts, 1k+ VMs) the discovery
script is seen to take about 10 minutes. This changes simply bumps the
default timeout up from 4 minutes to 15 minutes to account for
that. In the future we may want to see if we can improve the speed of
discovery perhaps by inventorying less data on individual hosts.