### PR TITLE
ASM-8057 ASM is not reporting failure when depl fails to exit maintenance mode

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -111,6 +111,7 @@ def collect_host_attributes(host)
   if get_host_config(host)
     attributes[:hostname] = get_host_config(host).network.dnsConfig.hostName
     attributes[:version] = get_host_config(host).product.version
+    attributes[:maintenance_mode] = host.runtime.inMaintenanceMode
   end
   attributes
 end


### PR DESCRIPTION
Adding server's maintenance mode addtibute for each server inventories by ASM. This will help in deciding if server's firmware update needs to be invoked