### PR TITLE
ASM-8218 Fix NoMethodError in rbvmomi lib in vcenter discovery

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -1,7 +1,8 @@
 #!/opt/puppet/bin/ruby
-require 'json'
-require 'rbvmomi'
-require 'trollop'
+require "json"
+require "rbvmomi"
+require_relative "../lib/puppet_x/puppetlabs/transport/rbvmomi_patch" # Use patched library to workaround rbvmomi issues
+require "trollop"
 
 opts = Trollop::options do
   opt :server, 'vcenter address', :type => :string, :required => true


### PR DESCRIPTION
Brownfield discovery were not getting service tag fields if invoked via
`host.esxcli.hardware.platform.get.SerialNumber.` The root cause is that 6.0
onwards the SOAP responses from esxcli are not missing return types for some
methods in rbvmomi gem we have. This creates errors like below:

```
NoMethodError: undefined method `name' for nil:NilClass
from /opt/puppet/lib/ruby/gems/1.9.1/gems/rbvmomi-1.8.2/lib/rbvmomi/vim/DynamicTypeMgrManagedTypeInfo.rb:33:in `block in toRbvmomiTypeHash'
```

We had seen same thing in esx_software_discovery script in the past and
had introduced a rbvmom_patch to resolve the missing return type issue. We
use this same patch after including rbvmomi gem to resolve the issue.