### PR TITLE
ASM-8331 Flag to not fail when maintenance mode state cannot be determined

### DIFF
--- a/lib/puppet/provider/esx_maintmode/default.rb
+++ b/lib/puppet/provider/esx_maintmode/default.rb
@@ -47,8 +47,16 @@ Puppet::Type.type(:esx_maintmode).provide(:esx_maintmode, :parent => Puppet::Pro
   def exists?
     begin
       host.runtime.inMaintenanceMode
-    rescue Exception => e
-      fail "Host is not available: -\n #{e.message}"
+    rescue => e
+      msg = "Could not determine maintenance mode state: %s" % e.message
+      if resource[:fail_when_undetermined]
+        fail msg
+      else
+        # If the flag is set to not fail when we cannot determine maintenance mode,
+        # we simply return value to prevent create/destroy to get invoked
+        Puppet.warning(msg)
+        resource[:ensure] == :present
+      end
     end
   end
 

--- a/lib/puppet/type/esx_maintmode.rb
+++ b/lib/puppet/type/esx_maintmode.rb
@@ -58,4 +58,15 @@ Puppet::Type.newtype(:esx_maintmode) do
     desc "describe VSAN action needs to be taken"
     newvalues('ensureObjectAccessibility', 'evacuateAllData', 'noAction')
   end
+
+  newparam(:fail_when_undetermined) do
+    desc "Flag to determine if we should raise error if state cannot be determined"
+
+    newvalues(:true, :false)
+    defaultto(:true)
+
+    munge do |v|
+      v == :true
+    end
+  end
 end


### PR DESCRIPTION
For some use cases, we may not want the maintenance mode resource exists
to fail if host is not available or maintenance mode state cannot be
determined. In such case, we provide a flag to prevent failure in exists?
and prevent unwanted invocation of create/destroy