### PR TITLE
ASM-8428 Intermittent error is observerd while enabling VSAN health and performance services

### DIFF
--- a/lib/puppet/provider/vc_vsan_health_performance/default.rb
+++ b/lib/puppet/provider/vc_vsan_health_performance/default.rb
@@ -9,6 +9,12 @@ Puppet::Type.type(:vc_vsan_health_performance).provide(:vc_vsan_health_performan
   def create
     Puppet.debug("Configuring VSAN performance service")
     vsan.vsanPerformanceManager.VsanPerfCreateStatsObjectTask(:cluster => cluster).onConnection(vim).wait_for_completion
+  rescue => ex
+    if ex.message =~ /FileAlreadyExists/
+      Puppet.debug("FileAlreadyExists error message received. Health services is aleady enabled. Need to ignore this error")
+    else
+      raise
+    end
   end
 
   def destroy


### PR DESCRIPTION
Included error handling for the scenario where intermittently existing method returns the status of health services as not configrued and while enabling the services getting "FlieAlreadyExists" error message