### PR TITLE
ASM-8580 Some vSAN deployments do not attach all the available disks to the cluster

### DIFF
--- a/lib/puppet/provider/vc_vsan_disk_initialize/default.rb
+++ b/lib/puppet/provider/vc_vsan_disk_initialize/default.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:vc_vsan_disk_initialize).provide(:vc_vsan_disk_initialize, :p
     host_disk_group_creation_initiated = hosts_task_info.keys
     while !hosts_task_info.keys.empty? do
       hosts_task_info.reject! do |host_name, task|
-        Puppet.debug("Task status for host #{host_name} is #{task.info.inspect}")
+        Puppet.debug("Task status for host %s is %s" % [host_name, task.info.state])
         task.info.state != "running"
       end
 
@@ -43,7 +43,7 @@ Puppet::Type.type(:vc_vsan_disk_initialize).provide(:vc_vsan_disk_initialize, :p
 
     while !hosts_task_info.keys.empty? do
       hosts_task_info.reject! do |host_name, task|
-        Puppet.debug("Task status for host #{host_name} is #{task.info.inspect}")
+        Puppet.debug("Task status for host %s is %s" % [host_name, task.info.state])
         task.info.state != "running"
       end
 


### PR DESCRIPTION
Added debug messages for VSAN disk selection so that we can collect the scenario where disks are skipped from the disk-group creation process.

Also, included a retry mechanism where free disks are identified after disk-group creation process is completed. If a free eligible disk(s) is identified which is not included in the existing disk-group then same will be added to the disk-groups

This code flow will also take care of the scenario where a new disk is added to the server after initial disk-group creation process. The newly added disk will included in the disk-group when retry of the service is initiated.