### PR TITLE
ASM-8666 vSAN tear down does not remove the cluster and host from vCenter

### DIFF
--- a/lib/puppet/provider/vc_dvswitch/default.rb
+++ b/lib/puppet/provider/vc_dvswitch/default.rb
@@ -116,6 +116,8 @@ Puppet::Type.type(:vc_dvswitch).provide(:vc_dvswitch, :parent => Puppet::Provide
     rescue Exception => e
       if e.message.match(/AlreadyExists:/i)
         Puppet.debug('Host already added to DVS')
+      elsif e.message.match(/The object or item referred to could not be found/i)
+        Puppet.debug("VDS resource is already removed. Received error message %s" % [e.message])
       else
         fail "#{e.message}"
       end


### PR DESCRIPTION
While retrying the VSAN teardown if the resource is already removed in the previous atttempt then cleanup operation fails with error "Item could not be found". We need to ignore this error and continue with the cleanup operation