### PR TITLE
ASM-8215 Update behavior and fix issues for VDS network scale up.

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -77,7 +77,7 @@ def collect_inventory(obj, parent=nil)
     when RbVmomi::VIM::HostSystem
       @host_count += 1
       hash[:attributes] = collect_host_attributes(obj)
-      (obj.vm + obj.datastore).each{ |vm| hash[:children] << collect_inventory(vm, obj)}
+      (obj.vm + obj.datastore + obj.network).each{ |vm| hash[:children] << collect_inventory(vm, obj)}
     when RbVmomi::VIM::VirtualMachine
       @vm_count += 1
       hash[:attributes] = collect_vm_attributes(obj)


### PR DESCRIPTION
we have included all standard and distributed port groups available on each of the server. This new information is added at the same level as VM and datastore. Here Type will be “DistributedVirtualPortgroup” or Network. VLAN ID is available as an attribute to it.

Example
{"name"=>"iscsi1",
             "id"=>"dvportgroup-696",
             "type"=>"DistributedVirtualPortgroup",
             "attributes"=>{"vlan_id"=>16},
             "children"=>[]},