### PR TITLE
Gem provider

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,30 +1,31 @@
 # Copyright (C) 2013 VMware, Inc.
 class vcenter::package (
+  $provider = $vcenter::params::provider,
 ) inherits vcenter::params {
 
   package { [
     'rest-client',
   ]:
     ensure   => present,
-    provider => $::vcenter::params::provider,
+    provider => $provider,
   }
 
   # net-ssh gem 2.1.4 (PE3) is incompatible with vcsa 5.5 security settings:
   package { 'net-ssh':
     ensure   => '2.7.0',
-    provider => $::vcenter::params::provider,
+    provider => $provider,
   }
 
   # hashdiff 1.0.0 is not compatible with PE
   package { 'hashdiff':
     ensure   => '0.0.6',
-    provider => $::vcenter::params::provider,
+    provider => $provider,
   }
 
   # nori 2.0.0 gem is not compatible with PE (nokogiri?)
   package { 'nori':
     ensure   => '1.1.5',
-    provider => $::vcenter::params::provider,
+    provider => $provider,
   }
 
   # custom gyoku to support array of attributes with no value:
@@ -40,7 +41,7 @@ class vcenter::package (
   package { 'gyoku':
     ensure   => '1.0.0z2',
     source   => '/opt/staging/vcenter/gyoku.gem',
-    provider => $::vcenter::params::provider,
+    provider => $provider,
   }
 
   staging::file { 'rbvmomi.gem':
@@ -50,6 +51,6 @@ class vcenter::package (
   package { 'rbvmomi':
     ensure   => '1.6.0.z1',
     source   => '/opt/staging/vcenter/rbvmomi.gem',
-    provider => $::vcenter::params::provider,
+    provider => $provider,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,16 @@
+{
+  "name": "vmware-vcenter",
+  "version": "0.10.0",
+  "author": "Puppet Labs | VMware 2013",
+  "license": "Apache-2.0",
+  "summary": "VMware vCenter puppet module",
+  "source": "git@github.com:vmware/vmware-vcenter.git",
+  "project_page": "https://github.com/vmware/vmware-vcenter",
+  "issues_url": "https://github.com/vmware/vmware-vcenter/issues",
+  "tags": ["vmware", "vcenter"],
+  "dependencies": [
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.0.0" },
+    { "name": "vmware/vmware_lib", "version_requirement": ">= 0.7.0" },
+    { "name": "nanliu/staging", "version_requirement": ">= 0.2.1" }
+  ]
+}


### PR DESCRIPTION
Allow for the gem_provider to be overridden by class definition or hiera. Enables support for Puppet 4 which has depreciated pe_gem in favor of built in puppet_gem provider. See https://github.com/puppetlabs/puppetlabs-pe_gem

Added metadata.json to allow for installation of dependencies with puppet module install command or forge. 