### PR TITLE
ASM-8604 Support DNS host name for host-ip during ESX software inventory

### DIFF
--- a/bin/esx_software_discovery.rb
+++ b/bin/esx_software_discovery.rb
@@ -23,6 +23,9 @@ def collect_esx_facts(vim, host_ip)
   puts "Fetching ESX facts for %s" % host_ip
 
   host = vim.root.findByIp(host_ip, RbVmomi::VIM::HostSystem)
+
+  host = vim.root.findByDnsName(host_ip, RbVmomi::VIM::HostSystem) unless host
+
   raise "Host '%s' not found" % host_ip if host.nil?
 
   hash = {:name => host.name, :id => host._ref, :type => host.class}


### PR DESCRIPTION
It is possible that host DNS-name may be passed as host_ip. In that case
we try out different VIM API.