### PR TITLE
ASM-8648 Changed cd/Dvd drive ide controller id

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -626,7 +626,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
     disk = RbVmomi::VIM.VirtualCdrom(
         :backing => RbVmomi::VIM.VirtualCdromRemotePassthroughBackingInfo(:deviceName => "CDROM", :exclusive => false, :useAutoDetect => false),
         :connectable => virtualcd_connect_info,
-        :controllerKey => 200, #IDE Controllers start at 200
+        :controllerKey => 201, #IDE Controllers start at 200
         :key => 999,
         :unitNumber => 0
     )


### PR DESCRIPTION
Previously existing ide controller 200 for(0:0) on vm cd failes
to install os on first disk.

This PR will change cd_drive controller id to install os on first available disk.