### PR TITLE
ASM-8811 Mounts ISO to CD/DVD drive for vm

### DIFF
--- a/lib/puppet/type/vc_vm.rb
+++ b/lib/puppet/type/vc_vm.rb
@@ -61,6 +61,10 @@ Puppet::Type.newtype(:vc_vm) do
     end
   end
 
+  newparam(:iso_file) do
+    desc 'iso file name to attach to cd_drive'
+  end
+
   newparam(:datastore) do
   end
 
@@ -109,6 +113,10 @@ Puppet::Type.newtype(:vc_vm) do
     desc 'Network Interfaces consist of a portgroup and nic_type'
     defaultto([])
   end
+
+  newparam(:nfs) do
+    desc 'nfs datastore hash to add nfs that contain iso file'
+    end
 
   newparam(:scsi_controller_type) do
     desc 'Virtual SCSI controller type for new Virtual Machine''s boot disk.'


### PR DESCRIPTION
Asm has no support for mounting iso.It creates empty
cd drive while creating VM.

This PR adds cd device config as parameters and runs puppet
to mount iso file by adding NFS datastore. It unmounts iso and
NFS after completing a specified task. multiple NFS datastore
may be attached on a host with VM specific name.