### PR TITLE
ASM-9004 Avoids Clone vm powerON to get vm networks

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
 
   def flush
     if resource[:ensure] == :present
-      self.power_state = :poweredOff unless @property_flush.empty?
+     self.power_state = :poweredOff unless (@property_flush.empty? || power_state == "poweredOff")
 
       if @property_flush[:network_vm_spec]
         vm.ReconfigVM_Task(
@@ -36,8 +36,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
       end
 
       configure_iso if @property_flush[:cd_iso_spec]
-
-      self.power_state = :poweredOn unless (resource[:power_state] == :poweredOff || power_state == "poweredOn")
+        self.power_state = :poweredOn unless (resource[:power_state] == :poweredOff || power_state == "poweredOn")
     end
   end
 


### PR DESCRIPTION
Previously clone vms always powersOn after creating vm.
with the recent changes to mount iso for configuring static network,
powering_on vm without mounting iso may cause issues.

This PR will make sure the vm is poweredOFf. Later, other puppet run by
asm-deployer will powerOn the vm after mounting iso on cdDrive.