### PR TITLE
ASM-9568 scaledown vol is not migrating vms to another vol

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -216,7 +216,8 @@ def get_host_config(host)
 end
 
 def collect_vm_attributes(vm)
-  {:template => vm.summary.config.template}
+  {:template => vm.summary.config.template,
+  :datastore => vm.datastore.first.name}
 end
 
 def collect_vds_portgroup_attributes(portgroup)

--- a/lib/puppet/type/vc_migratevm.rb
+++ b/lib/puppet/type/vc_migratevm.rb
@@ -48,6 +48,15 @@ Puppet::Type.newtype(:vc_migratevm) do
     end
   end
 
+  newparam(:cluster) do
+    desc "Name of the cluster."
+    validate do |value|
+      if value.strip.length == 0
+        raise ArgumentError, "Invalid cluster name."
+      end
+    end
+  end
+
   newparam(:disk_format) do
     desc "Type of virtual disk format"
     newvalues(:thin, :thick , :same_as_source)

--- a/tests/vc_migratevm.pp
+++ b/tests/vc_migratevm.pp
@@ -6,6 +6,7 @@ $migrate_vm = {
   target_host      => '172.16.100.56' ,
   target           => '172.16.100.56, gale-fsr',
   datacenter       => 'DDCQA',
+  cluster          => 'MyCluster'
 }
 
 transport { 'vcenter':
@@ -20,6 +21,7 @@ vc_migratevm { $migrate_vm['vmname']:
   #migratevm_host           => $migrate_vm['target_host'],
   #migratevm_host_datastore => $migrate_vm['target'],
   datacenter                => $migrate_vm['datacenter'],
+  cluster                   => $migrate_vm['cluster'],
   disk_format               => 'thin' ,
   transport                 => Transport['vcenter'],
 }


### PR DESCRIPTION
In case empty datastore name is passed then we check for all available datastore having sufficient disk space for hosting the Virtual Machine.
Include datastore name in the discovery data of Virtual machine. This helps in identifying VMs hosted on a specific datastore.