### PR TITLE
ASM-9650 VM Datastore migration failing for SDRS based storage

### DIFF
--- a/lib/puppet/provider/vc_migratevm/default.rb
+++ b/lib/puppet/provider/vc_migratevm/default.rb
@@ -154,7 +154,7 @@ Puppet::Type.type(:vc_migratevm).provide(:vc_migratevm, :parent => Puppet::Provi
       }
       info
     end.compact
-    Puppet.debug("Found Storage Pods: %s") % [datastore_info]
+    Puppet.debug("Found Storage Pods: %s" % [datastore_info])
     datastore_info
   end
 


### PR DESCRIPTION
Debug message added for listing the selected datastore was not in correct sprintf format, leading to the syntax error.