### PR TITLE
ASM-8072 Increase vcenter inventory timeout to 1 hour

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -9,7 +9,7 @@ opts = Trollop::options do
   opt :port, 'vcenter port', :default => 443
   opt :username, 'vcenter username', :type => :string, :required => true
   opt :password, 'vcenter password', :type => :string, :default => ENV['PASSWORD']
-  opt :timeout, 'command timeout', :default => 900
+  opt :timeout, 'command timeout', :default => 3600
   opt :community_string, 'dummy value for ASM, not used'
   opt :credential_id, 'dummy value for ASM, not used'
   opt :output, 'output facts to a file', :type => :string, :required => true


### PR DESCRIPTION
In 8.3.1 the timeout was increased from 4 minutes to 15 minutes. The
script was timing out against some vcenters with large inventory
including remote ESXi hosts. Recently the same vcenter was seen to
take 24 minutes to inventory so it was still timing out. For now
bumping the timeout up to 1 hour to cover that case. At some point we
need to find some way to optimize this.