### PR TITLE
ASM-9693 VM MIgration failed during scale-down of the datastore

### DIFF
--- a/lib/puppet/provider/vc_migratevm/default.rb
+++ b/lib/puppet/provider/vc_migratevm/default.rb
@@ -134,7 +134,7 @@ Puppet::Type.type(:vc_migratevm).provide(:vc_migratevm, :parent => Puppet::Provi
       datastore_info.reject! {|d| d["name"] == vm_datastore_name}
       datastore_selected = datastore_info.find { |d| d["free"] >= vm_disk_usage }
       raise("No datastore found with sufficient free space") unless datastore_selected
-      Puppet.debug("Selected datastore: %s") % [datastore_selected["name"]]
+      Puppet.debug("Selected datastore: %s" % [datastore_selected["name"]])
       datastore_selected["name"]
     end
   end


### PR DESCRIPTION
There is a typo in the debug message which prints the name of the datastore selected for the migration. This statement was updated as part of the code review and a typo got introduced there