### PR TITLE
LUD-204 Create ScaleiO CentOS VM on specific host / datastore in the cluster

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -566,7 +566,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
       size = d['summary.capacity']
       free = d['summary.freeSpace']
       used = size - free
-      is_local = d['name'].match(/local-storage-\d+/)
+      is_local = d['name'].match(/local-storage-\d+|DAS\d+/)
       info = {
           'name' => d['name'], 'size' => size, 'free' => free, 'used' => used,
           'info' => d['info'], 'summary' => d['summary'], 'is_local' => is_local
@@ -584,8 +584,8 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
     if !requested_datastore.empty?
       info = datastore_info.find { |d| d['name'] == requested_datastore }
       raise("Datastore #{requested_datastore} not found") unless info
-      raise("In-sufficient space in datastore #{requested_datastore}") unless free < requested_size
-      requested_datastore
+      raise("In-sufficient space in datastore #{requested_datastore}") unless info['free'] < requested_size
+      info
     else
       datastore_selected = datastore_info.find { |d| d['free'] >= requested_size }
       raise("No datastore found with sufficient free space") unless datastore_selected


### PR DESCRIPTION
While passing the specific datastore name for VM creation, operation was failing in the debug message.
Also in the return statement we were just sending the name of the datastore (old convention) but with the new code structure, datastore object information was required.
Validated the code for VM creation on specific host in the cluster.