### PR TITLE
LUD-224 Do not pick NFS share for VM deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :development, :test do
   gem 'puppetlabs_spec_helper', :require => false
   gem 'rspec-puppet', :require => false
   gem 'puppet-lint', :require => false
-  gem "pry"
 end
 
 facterversion = ENV['GEM_FACTER_VERSION']

--- a/lib/puppet/provider/esx_datastore/default.rb
+++ b/lib/puppet/provider/esx_datastore/default.rb
@@ -22,7 +22,6 @@ Puppet::Type.type(:esx_datastore).provide(:esx_datastore, :parent => Puppet::Pro
       when 'VMFS'
         attempt = 10
         while ! create_vmfs_lun and ! exists? and attempt > 0
-          require "pry"; binding.pry
           Puppet.debug('Rescanning for volume')
           host.configManager.storageSystem.RescanAllHba() unless find_disk
           host.configManager.storageSystem.RescanVmfs()

--- a/spec/unit/puppet/provider/vc_vm/vc_vm_spec.rb
+++ b/spec/unit/puppet/provider/vc_vm/vc_vm_spec.rb
@@ -1,54 +1,50 @@
-require 'spec_helper'
-require 'yaml'
-require 'puppet/provider/vcenter'
-require 'rspec/mocks'
-require 'fixtures/unit/puppet/provider/vc_vm/vc_vm_fixture'
+require "spec_helper"
+require "yaml"
+require "puppet/provider/vcenter"
+require "rspec/mocks"
+require "fixtures/unit/puppet/provider/vc_vm/vc_vm_fixture"
+require "hashie"
 
 describe "vm create and clone behavior testing" do
-  before(:each) do
-    @fixture = Vc_vm_fixture.new
-    @fixture.provider.stubs(:create_vm)
-    @fixture.provider.stubs(:clone_vm)
-    @fixture.provider.stubs(:delete_vm)
-    @fixture.provider.stubs(:check_vm)
-  end
+  let(:fixture) {Vc_vm_fixture.new}
+  let(:provider) {fixture.provider}
 
   context "when vc_vm provider is created " do
     it "should have a create method defined for vc_vm" do
-      @fixture.provider.class.instance_method(:create).should_not == nil
+      expect(provider.class.instance_method(:create)).to be_truthy
     end
 
     it "should have a destroy method defined for vc_vm" do
-      @fixture.provider.class.instance_method(:destroy).should_not == nil
+      expect(provider.class.instance_method(:destroy)).to be_truthy
     end
 
     it "should have a exists? method defined for vc_vm" do
-      @fixture.provider.class.instance_method(:exists?).should_not == nil
+      expect(provider.class.instance_method(:exists?)).to be_truthy
     end
 
     it "should have a parent 'Puppet::Provider::Vcentre'" do
-      @fixture.provider.should be_kind_of(Puppet::Provider::Vcenter)
+      expect(provider).to be_kind_of(Puppet::Provider::Vcenter)
     end
   end
 
   context "when vc_vm is created " do
     before(:each) do
-      @fixture.provider.expects(:vm).at_least_once.returns(nil).returns(mock("vm_object"))
-      @fixture.provider.expects(:cdrom_iso).returns(mock("cdrom_object"))
-      @fixture.provider.expects(:configure_iso)
+      provider.expects(:vm).at_least_once.returns(nil).returns(mock("vm_object"))
+      provider.expects(:cdrom_iso).returns(mock("cdrom_object"))
+      provider.expects(:configure_iso)
     end
 
     it "should create vm  if value of operation is create" do
-      @fixture.provider.expects(:create_vm)
+      provider.expects(:create_vm)
 
-      @fixture.provider.create
+      provider.create
     end
 
     it "should clone vm  if value of operation is clone" do
-      @fixture.provider.resource[:template] = "mock_template"
-      @fixture.provider.expects(:clone_vm)
+      provider.resource[:template] = "mock_template"
+      provider.expects(:clone_vm)
 
-      @fixture.provider.create
+      provider.create
     end
   end
 
@@ -56,23 +52,205 @@ describe "vm create and clone behavior testing" do
     let(:destroy_task) {mock("destroy_task")}
 
     before(:each) do
-      @fixture.provider.stubs(:power_state).returns("poweredOff")
-      @fixture.provider.stubs(:cdrom_iso)
-      @fixture.provider.stubs(:nfs_vm_datastore)
+      provider.stubs(:power_state).returns("poweredOff")
+      provider.stubs(:cdrom_iso)
+      provider.stubs(:nfs_vm_datastore)
     end
 
     it "should delete vm " do
-      @fixture.provider.stubs(:vm).returns(mock(:Destroy_Task => destroy_task))
+      provider.stubs(:vm).returns(mock(:Destroy_Task => destroy_task))
 
       destroy_task.expects(:wait_for_completion)
 
-      @fixture.provider.destroy
+      provider.destroy
     end
 
     it "should receive error if vm not exist" do
-      @fixture.provider.stubs(:vm)
+      provider.stubs(:vm)
 
-      expect {@fixture.provider.destroy}.to raise_error(/undefined method `Destroy_Task' for nil/)
+      expect {provider.destroy}.to raise_error(/undefined method `Destroy_Task' for nil/)
+    end
+  end
+
+  context "#is_internal_nfs_datastore?" do
+    it "should return true when name starts with _nfs_asm" do
+      expect(provider.is_internal_nfs_datastore?("_nfs_asm_vm1")).to be_truthy
+    end
+
+    it "should return false otherwise" do
+      expect(provider.is_internal_nfs_datastore?("gs4esx2-local-storage-1")).to be_falsey
+    end
+  end
+
+  context "#is_local_datastore?" do
+    it "should return true for local storage" do
+      expect(provider.is_local_datastore?("gs4esx2-local-storage-1")).to be_truthy
+    end
+
+    it "should return true for DAS storage" do
+      expect(provider.is_local_datastore?("DAS198374")).to be_truthy
+    end
+
+    it "should return false otherwise" do
+      expect(provider.is_local_datastore?("_nfs_asm_gs4vm2")).to be_falsey
+    end
+  end
+
+  context "#usable_datastore?" do
+    let(:datastore) {{"name" => "generic-storage-1", "summary.accessible" => true}}
+
+    it "should return false for internal NFS datastores" do
+      expect(provider.usable_datastore?(datastore.merge("name" => "_nfs_asm_vm1"))).to be_falsey
+    end
+
+    it "should return false for inaccessible datastores" do
+      expect(provider.usable_datastore?(datastore.merge("summary.accessible" => false))).to be_falsey
+    end
+
+    it "should return true for remote datastores" do
+      expect(provider.usable_datastore?(datastore.merge("name" => "iscsi-storage-1"))).to be_truthy
+    end
+
+    it "should return true for local datastores unless `:skip_local_datastore`" do
+      provider.resource[:skip_local_datastore] = :false
+      expect(provider.usable_datastore?(datastore.merge("name" => "gs4esx2-local-storage-1"))).to be_truthy
+    end
+
+    it "should return false for local datastores if `:skip_local_datastore`" do
+      provider.resource[:skip_local_datastore] = :true
+      expect(provider.usable_datastore?(datastore.merge("name" => "gs4esx2-local-storage-1"))).to be_falsey
+    end
+  end
+
+  context "datastore sorting" do
+    let(:pods) {
+      [
+          {"name" => "pod-storage-1",
+           "pod" => true,
+           "info" => mock("pod-storage-1_info"),
+           "summary" => mock("pod-storage-1_summary"),
+           "summary.capacity" => 591363309568,
+           "summary.freeSpace" => 564766179328,
+           "free" => 564766179328,
+           "summary.accessible" => true},
+          {"name" => "pod-storage-2",
+           "pod" => true,
+           "info" => mock("pod-storage-1_info"),
+           "summary" => mock("pod-storage-1_summary"),
+           "summary.capacity" => 591363309568,
+           "summary.freeSpace" => 179328,
+           "free" => 179328,
+           "summary.accessible" => true}
+      ]
+    }
+
+    let(:datastores) {
+      [
+          {"name" => "iscsi-storage-1",
+           "iscsi" => true,
+           "info" => mock("iscsi-storage-1_info"),
+           "summary" => mock("iscsi-storage-1_summary"),
+           "summary.capacity" => 591363309568,
+           "summary.freeSpace" => 564766179328,
+           "summary.accessible" => true},
+          {"name" => "iscsi-storage-2",
+           "iscsi" => true,
+           "info" => mock("iscsi-storage-2_info"),
+           "summary" => mock("iscsi-storage-2_summary"),
+           "summary.capacity" => 591363309568,
+           "summary.freeSpace" => 179328,
+           "summary.accessible" => true},
+          {"name" => "iscsi-storage-inaccessible",
+           "iscsi" => true,
+           "info" => mock("iscsi-storage-inaccessible_info"),
+           "summary" => mock("iscsi-storage-inaccessible_summary"),
+           "summary.capacity" => 591363309568,
+           "summary.freeSpace" => 179328,
+           "summary.accessible" => false},
+          {"name" => "gs4esx2-local-storage-1",
+           "info" => mock("gs4esx2-local-storage-1_info"),
+           "summary" => mock("gs4esx2-local-storage-1_summary"),
+           "summary.capacity" => 591363309568,
+           "summary.freeSpace" => 564766179328,
+           "summary.accessible" => true},
+          {"name" => "gs4esx2-local-storage-2",
+           "info" => mock("gs4esx2-local-storage-2_info"),
+           "summary" => mock("gs4esx2-local-storage-2_summary"),
+           "summary.capacity" => 591363309568,
+           "summary.freeSpace" => 98347987,
+           "summary.accessible" => true},
+          {"name" => "_nfs_asm_gs5vm1",
+           "info" => mock("_nfs_asm_gs5vm1_info"),
+           "summary" => mock("_nfs_asm_gs5vm1_summary"),
+           "summary.capacity" => 52710469632,
+           "summary.freeSpace" => 45187215360,
+           "summary.accessible" => false}]
+    }
+
+    context "#prioritized_datastores" do
+      it "should order by pods, remote, then local datastores" do
+        provider.expects(:get_cluster_storage_pods).returns(pods.sort_by {rand})
+
+        prioritized = provider.prioritized_datastores(datastores.sort_by {rand})
+
+        expected = (pods + datastores.reject {|d| !d["summary.accessible"]}).map {|d| d["name"]}
+
+        expect(prioritized.map {|d| d["name"]}).to eq(expected)
+      end
+
+      it "not require pods" do
+        provider.expects(:get_cluster_storage_pods).returns([])
+
+        prioritized = provider.prioritized_datastores(datastores.sort_by {rand})
+
+        expected = datastores.reject {|d| !d["summary.accessible"]}.map {|d| d["name"]}
+
+        expect(prioritized.map {|d| d["name"]}).to eq(expected)
+      end
+    end
+
+    context "#get_cluster_datastore" do
+      let(:retriever) {mock("RetrieveProperties")}
+      let(:vim) {mock(:propertyCollector => retriever)}
+      let(:cluster) {mock(:datastore => [])}
+
+      before(:each) do
+        provider.stubs(:vim).returns(vim)
+        provider.stubs(:cluster).returns(cluster)
+      end
+
+      it "should return the best datastore" do
+        provider.resource[:datastore] = "" # pick it instead
+        retriever.expects(:RetrieveProperties).returns(datastores)
+        provider.expects(:get_cluster_storage_pods).returns([])
+
+        expect(provider.get_cluster_datastore["name"]).to eq("iscsi-storage-1")
+      end
+
+      it "should return the requested datastore" do
+        provider.resource[:datastore] = "gs4esx2-local-storage-1"
+        retriever.expects(:RetrieveProperties).returns(datastores)
+        provider.expects(:get_cluster_storage_pods).returns([])
+
+        expect(provider.get_cluster_datastore["name"]).to eq("gs4esx2-local-storage-1")
+      end
+
+      it "should fail if the requested datastore is not found" do
+        retriever.expects(:RetrieveProperties).returns(datastores)
+        provider.expects(:get_cluster_storage_pods).returns([])
+
+        expect {provider.get_cluster_datastore}.to raise_error("Datastore gale-fsr not found")
+      end
+
+      it "should fail if no datastore is big enough" do
+        provider.resource[:datastore] = "" # pick it instead
+        provider.resource[:virtual_disks] = [{"size" => 500000}, {"size" => 500000}]
+
+        retriever.expects(:RetrieveProperties).returns(datastores)
+        provider.expects(:get_cluster_storage_pods).returns([])
+
+        expect {provider.get_cluster_datastore}.to raise_error("No datastore found with sufficient free space")
+      end
     end
   end
 end


### PR DESCRIPTION
LUD-224 Do not pick NFS share for VM deployment

An NFS datastore is used to mount ISO images, i.e. to boot a VM off of
an ISO image. Those datastores were getting picked for VM deployment
on ESXi hosts that only had local datastores. That is because they are
interpreted as "remote datastores" which are prioritized above local
datastores.

Also adds some general unit testing aroung the related
`get_cluster_datastore` functionality.
