### PR TITLE
LUD-38 NIC teaming mode to support Hypervisor deployment

### DIFF
--- a/lib/puppet/provider/esx_portgroup/default.rb
+++ b/lib/puppet/provider/esx_portgroup/default.rb
@@ -653,7 +653,7 @@ Puppet::Type.type(:esx_portgroup).provide(:esx_portgroup, :parent => Puppet::Pro
       hostnicorderpolicy = nil
     end
 
-    hostnicteamingpolicy = RbVmomi::VIM.HostNicTeamingPolicy(:nicOrder => hostnicorderpolicy)
+    hostnicteamingpolicy = RbVmomi::VIM.HostNicTeamingPolicy(:nicOrder => hostnicorderpolicy, :policy => resource[:uplinkteamingpolicy])
     hostnetworkpolicy = RbVmomi::VIM.HostNetworkPolicy(:nicTeaming=> hostnicteamingpolicy)
 
     if (actualspec.policy != nil )

--- a/lib/puppet/provider/vc_dvportgroup/default.rb
+++ b/lib/puppet/provider/vc_dvportgroup/default.rb
@@ -88,7 +88,7 @@ Puppet::Type.type(:vc_dvportgroup).provide(:vc_dvportgroup, :parent => Puppet::P
         Puppet.debug "requiring: #{@properties_reqd.sort.inspect} are required"
         # properties_reqd may change
         # properties_rcvd will change unless resource has no value for property
-        properties_reqd.dup.each{|p| 
+        properties_reqd.dup.each{|p|
           self.send "#{p}=".to_sym, @resource[p] unless @resource[p].nil?
         }
       end

--- a/lib/puppet/provider/vc_dvswitch/default.rb
+++ b/lib/puppet/provider/vc_dvswitch/default.rb
@@ -62,7 +62,6 @@ Puppet::Type.type(:vc_dvswitch).provide(:vc_dvswitch, :parent => Puppet::Provide
         PuppetX::VMware::Util::nested_value(config_is_now, leaf.path_is_now)
       )
     end
-
     define_method("#{leaf.prop_name}=".to_sym) do |value|
       PuppetX::VMware::Util::nested_value_set(config_should, leaf.path_should, value)
       properties_rcvd.add leaf.prop_name
@@ -90,7 +89,7 @@ Puppet::Type.type(:vc_dvswitch).provide(:vc_dvswitch, :parent => Puppet::Provide
         Puppet.debug "requiring: #{@properties_reqd.inspect} are required"
         # properties_reqd may change
         # properties_rcvd will change unless resource has no value for property
-        properties_reqd.dup.each{|p| 
+        properties_reqd.dup.each {|p|
           self.send "#{p}=".to_sym, @resource[p] unless @resource[p].nil?
         }
       end

--- a/lib/puppet/type/esx_portgroup.rb
+++ b/lib/puppet/type/esx_portgroup.rb
@@ -73,6 +73,11 @@ Puppet::Type.newtype(:esx_portgroup) do
     desc "nic order ploicy to be applied to vSwitch"
   end
 
+  newparam(:uplinkteamingpolicy) do
+    desc "teaming policy for portgroup"
+    defaultto("loadbalance_srcid")
+  end
+
   newparam(:portgrouptype) do
     desc "Type of port group."
     newvalues(:VirtualMachine, :VMkernel)


### PR DESCRIPTION
This PR supports nic teaming policy for vswitch and dvswitch.