### PR TITLE
LUD-1216 allow spaces in VDS and portgroup names

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -998,7 +998,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
   def network_specs(interfaces=resource[:network_interfaces], action='add')
     interfaces.each_with_index.collect do |nic, index|
       portgroup = nic['portgroup']
-      if portgroup.match(/(\S+)\s*\((\S+)\)/)
+      if portgroup.match(/^(\b.*?)\ \((.*?)\)$/)
         backing = RbVmomi::VIM.VirtualEthernetCardDistributedVirtualPortBackingInfo
         port = RbVmomi::VIM.DistributedVirtualSwitchPortConnection
         port.portgroupKey = dvportgroup($2,$1).key


### PR DESCRIPTION
Initially, the jira issue describes the problem for VDS name with
spaces only. However, tests show that distributed portgroups names
can also cause failure.

At first, the solution was to be implemented on the asm-deployer,
but handling different types of backing data for network device
configuration still seemed to have other issues. After tracking the
root cause, the issue has been found in the regex, used for parsing
portgroup / vds names.

The old regex only works with interface name that contains no space
in both portgroup and vds names, e.g., "portgroup_name (vds_name)".
This new regex is able to handle the old case as well as names
that contain space(s). Now the names can be passed with a single
or multiple spaces, e.g., "portgroup name (vds name)" and
"pg 1 test (test vds 1234)".