### PR TITLE
VXFM-1662 Puppet logs are ludicrously large

### DIFF
--- a/lib/puppet/provider/esx_vmknic/default.rb
+++ b/lib/puppet/provider/esx_vmknic/default.rb
@@ -128,8 +128,6 @@ Puppet::Type.type(:esx_vmknic).provide(:esx_vmknic, :parent => Puppet::Provider:
     end
 
     # create RbVmomi objects with properties in place of hashes with keys
-    Puppet.debug "'is_now' is #{hide_password(config_is_now.inspect)}'}"
-    Puppet.debug "'should' is #{hide_password(config_should.inspect)}'}"
     spec = map.objectify config_should
     Puppet.debug "'object' is #{spec.inspect}'}"
     spec

--- a/lib/puppet/provider/vc_cluster_ha/default.rb
+++ b/lib/puppet/provider/vc_cluster_ha/default.rb
@@ -70,8 +70,6 @@ Puppet::Type.type(:vc_cluster_ha).provide(:vc_cluster_ha, :parent => Puppet::Pro
     end
 
     # create RbVmomi objects with properties in place of hashes with keys
-    Puppet.debug "'is_now' is #{hide_password(configurationEx_is_now.inspect)}'}"
-    Puppet.debug "'should' is #{hide_password(configurationEx_should.inspect)}'}"
     configurationEx_object = 
       clusterConfigSpecExMap.objectify configurationEx_should
     Puppet.debug "'object' is #{configurationEx_object.inspect}'}"

--- a/lib/puppet/provider/vc_dvportgroup/default.rb
+++ b/lib/puppet/provider/vc_dvportgroup/default.rb
@@ -100,8 +100,6 @@ Puppet::Type.type(:vc_dvportgroup).provide(:vc_dvportgroup, :parent => Puppet::P
     end
 
     # create RbVmomi objects with properties in place of hashes with keys
-    Puppet.debug "'is_now' is #{hide_password(config_is_now.inspect)}'}"
-    Puppet.debug "'should' is #{hide_password(config_should.inspect)}'}"
     spec = map.objectify config_should
     Puppet.debug "'object' is #{spec.inspect}'}"
     spec

--- a/lib/puppet/provider/vc_dvswitch/default.rb
+++ b/lib/puppet/provider/vc_dvswitch/default.rb
@@ -100,8 +100,6 @@ Puppet::Type.type(:vc_dvswitch).provide(:vc_dvswitch, :parent => Puppet::Provide
     end
 
     # create RbVmomi objects with properties in place of hashes with keys
-    Puppet.debug "'is_now' is #{hide_password(config_is_now.inspect)}'}"
-    Puppet.debug "'should' is #{hide_password(config_should.inspect)}'}"
     spec = map.objectify config_should
     Puppet.debug "'object' is #{spec.inspect}'}"
     spec

--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -682,8 +682,6 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
     data = vim.propertyCollector.RetrieveProperties(:specSet => [filterSpec])
 
     datastore_info = prioritized_datastores(data)
-
-    Puppet.debug("Datastore info: %s" % hide_password(datastore_info.to_s))
     Puppet.debug("Requested size: #{requested_size}")
 
     if !requested_datastore.empty?


### PR DESCRIPTION
Several debugging statements in the vcenter puppet code were dumping
huge (10-27MB per line) object data thereby creating very large
log files. This fix deletes the offending debug statements as they
were deemed unnecessary.