### PR TITLE
VXFM-2342 changes for configuring PCI device in server swimlane

### DIFF
--- a/lib/puppet/type/esx_pci_passthru_system.rb
+++ b/lib/puppet/type/esx_pci_passthru_system.rb
@@ -34,6 +34,10 @@ Puppet::Type.newtype(:esx_pci_passthru_system) do
     desc "Timeout value for host reboot event."
   end
 
+  newparam(:require_reboot, :boolean => false, :parent => Puppet::Parameter::Boolean) do
+    desc "Determines if host reboot is required."
+  end
+
   autorequire(:vc_host) do
     self[:host]
   end


### PR DESCRIPTION
To allow the server configuration in server swimlane, provider
and type for esx_pci_passthru_system resource are modified.

Now reboot is requested after configuring the target PCI device
only when require_reboot is true. Also, reboot method will no
longer enter and exit maintenance mode. Instead, this type of
tasks should be defined in the puppet resource through dependencies
on esx_maintmode resource.