### PR TITLE
VXFM-2146 fix problems when vcenter transport is used

### DIFF
--- a/lib/puppet/provider/vcenter.rb
+++ b/lib/puppet/provider/vcenter.rb
@@ -101,6 +101,7 @@ class Puppet::Provider::Vcenter <  Puppet::Provider
         dc = walk(path, RbVmomi::VIM::Datacenter) or fail("No datacenter in path: #{path}")
         vim.searchIndex.FindByDnsName(:datacenter => dc, :dnsName => host, :vmSearch => false)
       elsif host =~ Resolv::IPv4::Regex
+        Puppet.debug("Looking for host, %s, by searching index." % host)
         vim.searchIndex.FindByIp(:ip => host, :vmSearch => false)
       else
         vim.searchIndex.FindByDnsName(:dnsName => host, :vmSearch => false)

--- a/lib/puppet_x/puppetlabs/transport/rbvmomi_patch.rb
+++ b/lib/puppet_x/puppetlabs/transport/rbvmomi_patch.rb
@@ -55,7 +55,7 @@ end
 # patch will overide execute method and supports esxi versions 6 and above
 RbVmomi::VIM::ReflectManagedMethodExecuter.send(:define_method, :execute) do |moid, method, args|
   soap_args = args.map do |k, v|
-    VIM::ReflectManagedMethodExecuterSoapArgument.new.tap do |soap_arg|
+    RbVmomi::VIM::ReflectManagedMethodExecuterSoapArgument.new.tap do |soap_arg|
       soap_arg.name = k
       xml = Builder::XmlMarkup.new :indent => 0
       _connection.obj2xml xml, k, :anyType, false, v


### PR DESCRIPTION
Since we didn't usually apply esx_software_update through vcenter
transport, there were patches that ignored it. Now, we are required
to support both esx_connection and vcenter transports, so these
changes were made to support vcenter transport.