### PR TITLE
VXFM-3109 Scale-down not removing node from cluster

### DIFF
--- a/lib/puppet/provider/esx_maintmode/default.rb
+++ b/lib/puppet/provider/esx_maintmode/default.rb
@@ -6,6 +6,11 @@ require 'rbvmomi'
 Puppet::Type.type(:esx_maintmode).provide(:esx_maintmode, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages vsphere hosts entering and exiting maintenance mode."
   def enterMaintenanceMode
+    if resource[:check_disconnected_state] && host.summary.runtime.connectionState != 'connected'
+      Puppet.debug("Server is not in connected state. Maintenance mode operation is skipped")
+      return true
+    end
+
     if resource[:vsan_action].nil?
       host.EnterMaintenanceMode_Task(:timeout => resource[:timeout],
                                      :evacuatePoweredOffVms => resource[:evacuate_powered_off_vms]).wait_for_completion

--- a/lib/puppet/type/esx_maintmode.rb
+++ b/lib/puppet/type/esx_maintmode.rb
@@ -69,4 +69,10 @@ Puppet::Type.newtype(:esx_maintmode) do
       v == :true
     end
   end
+
+  newparam(:check_disconnected_state) do
+    desc "Check server connected state, perform operation only when server is connected"
+    newvalues(true, false)
+    defaultto(false)
+  end
 end


### PR DESCRIPTION
Skip maintenace mode operation while removing the server from maintenance mode if server is in disconnected state