### PR TITLE
VXFM-3435 Wrong disk mapped on CO deployment

### DIFF
--- a/lib/puppet/provider/esx_datastore/default.rb
+++ b/lib/puppet/provider/esx_datastore/default.rb
@@ -47,10 +47,15 @@ Puppet::Type.type(:esx_datastore).provide(:esx_datastore, :parent => Puppet::Pro
   def find_disk
 
     target_iqn = resource[:target_iqn]
+    target_model = resource[:target_model]
+    target_disk_id = resource[:target_disk_id]
 
     if target_iqn
       @disk ||= host.configManager.datastoreSystem.QueryAvailableDisksForVmfs().
       find_all{|disk| scsi_target_iqn(disk.uuid) == target_iqn }.last
+    elsif target_model && target_disk_id
+      @disk ||= host.configManager.datastoreSystem.QueryAvailableDisksForVmfs().
+        find_all{|disk| disk.model == target_model && disk.deviceName.include?(target_disk_id) && scsi_lun(disk.uuid) == resource[:lun]}.last
     else
       @disk ||= host.configManager.datastoreSystem.QueryAvailableDisksForVmfs().
       find_all{|disk| scsi_lun(disk.uuid) == resource[:lun]}.last

--- a/lib/puppet/type/esx_datastore.rb
+++ b/lib/puppet/type/esx_datastore.rb
@@ -86,6 +86,14 @@ Puppet::Type.newtype(:esx_datastore) do
     desc "Target IQN of lun created on storage."
   end
 
+  newparam(:target_model) do
+    desc "Target disk model name."
+  end
+
+  newparam(:target_disk_id) do
+    desc "Target disk unique identifier."
+  end
+
   newparam(:path) do
     desc "Datacenter path where host resides"
   end


### PR DESCRIPTION
Included parameter disk model and disk id for searching the disk that needs to be mapped and mounted as a datastore. In case there are multile local disks, then all of them becomes cadidate to be mounted as the datastore. Now we we will check for model, target id and lun id before mounting the volume as a datastore