### PR TITLE
VXFM-3911 Discovery of vCenter fails when orphan VMs are available on vCenter

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -280,7 +280,7 @@ def collect_vm_attributes(vm)
   {:template => vm.summary.config.template,
   :hostname => vm.summary.guest.hostName,
   :vm_ips => ip_list,
-  :datastore => vm.datastore.first.name,
+  :datastore => vm.datastore.first.nil? || vm.datastore.first.empty? ? "" : vm.datastore.first.name,
   :num_cpu => vm.summary.config.numCpu,
   :disk_size_gb => disk_size_gb,
   :memory_size_mb => vm.summary.config.memorySizeMB}


### PR DESCRIPTION
Discovery operation fails while fetching the datastore information of the VM. For Orphan VMs, datastore information is missing from the vCenter MOB. We are skipping the datastore information from the discovery data in case there is not datastore attached to the virtual machine.