### PR TITLE
VXFM-3944 VMK NIC Type update is failing for vMotion distributed port-group for new port-group

### DIFF
--- a/lib/puppet/provider/esx_vmknic_type/default.rb
+++ b/lib/puppet/provider/esx_vmknic_type/default.rb
@@ -63,6 +63,15 @@ Puppet::Type.type(:esx_vmknic_type).provide(:esx_vmknic_type, :parent => Puppet:
         vnm.SelectVnicForNicType(:nicType => type, :device => device)
       rescue RbVmomi::VIM::InvalidArgument => e
         fail e.message
+      rescue
+        retry_counter ||= 1
+        fail $!.message if retry_counter > 5
+
+        Puppet.debug("Failed to update NIC Type %s for %s" % [should, device])
+        sleep(60)
+        retry_counter += 1
+
+        retry
       end
     end
     deselect.sort.each do |type|


### PR DESCRIPTION
Intermittently VMK NIC Type update to vMotion is failing when distributed switch and port-group is created on the switch. Added sleep and retry for this process to ensure distributed port-group is in a stable state when new server is added to the distributed port-group