### PR TITLE
VXFM-3187 VMNIC configuration fails intermittently while finding dvs switch uuid

### DIFF
--- a/lib/puppet/provider/esx_vmknic/default.rb
+++ b/lib/puppet/provider/esx_vmknic/default.rb
@@ -33,9 +33,10 @@ Puppet::Type.type(:esx_vmknic).provide(:esx_vmknic, :parent => Puppet::Provider:
         @create_message << "#{leaf.full_name} => #{value.inspect}"
       end
     end
-    nic_spec = flush_prep
-    # :portgroup should be '' if working against dvswitch, else give it a value
+    
     begin
+      nic_spec = flush_prep
+      # :portgroup should be '' if working against dvswitch, else give it a value
       esxhost.configManager.networkSystem.AddVirtualNic(:portgroup => @resource[:portgroup],
                                                         :nic => nic_spec)
     rescue


### PR DESCRIPTION
VMNIC needs to be attached to a specific port on VDS switch. Intermittently port is already used and correct ID is not determined. Need to wait and re-created the configuration in case of failure.