### PR TITLE
VXFM-4321 ESXi 6.0 VIB is missing signature

### DIFF
--- a/lib/puppet/provider/esx_software_update/default.rb
+++ b/lib/puppet/provider/esx_software_update/default.rb
@@ -236,7 +236,7 @@ Puppet::Type.type(:esx_software_update).provide(:esx_software_update, :parent =>
       end
     end
 
-    host.esxcli.software.vib.install(install_param => qualified_path)
+    host.esxcli.software.vib.install(install_param => qualified_path, :nosigcheck => @resource[:no_sign_check])
   end
 
   # Esxcli wrapper method to remove a VIB represented by VIB name

--- a/lib/puppet/type/esx_software_update.rb
+++ b/lib/puppet/type/esx_software_update.rb
@@ -47,6 +47,12 @@ Puppet::Type.newtype(:esx_software_update) do
     end
   end
 
+  newparam(:no_sign_check) do
+    desc "Parameter to allow un-signed VIBs to be installed on the server."
+    newvalues(true, false)
+    defaultto(false)
+  end
+
   newparam(:host, :namevar => true) do
     desc "The ESX host"
     validate do |value|


### PR DESCRIPTION
Added support for installation of unsigned VIBs by ignoring the VIB signature. In case the flag is passed, then VIB without signature will be installed. Default behavior still remains the same where unsigned VIB will not be installed