### PR TITLE
VXFM-4346 VDS creation is failing for vCenter 6.7

### DIFF
--- a/lib/puppet/provider/vc_dvswitch/default.rb
+++ b/lib/puppet/provider/vc_dvswitch/default.rb
@@ -237,7 +237,7 @@ Puppet::Type.type(:vc_dvswitch).provide(:vc_dvswitch, :parent => Puppet::Provide
 
   def host_version(host)
     @host ||= vim.searchIndex.FindByDnsName(:datacenter => datacenter , :dnsName => host, :vmSearch => false) or raise(Puppet::Error, "Unable to find the host '#{host}'")
-    @host.summary.config.product.version
+    ver = @host.summary.config.product.version
+    ver == "6.7.0" ? "6.6.0" : ver
   end
-
 end


### PR DESCRIPTION
For ESXi 6.7 we need to pass VDS version as 6.6.0. This is a one of case required for this version