### PR TITLE
VXFM-6023 Log collection fails with VxFM-deployed VxFlex OS cluster

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -28,8 +28,8 @@ define vcenter::host (
       policy => 'off',
     },
     ssh => {
-      running => false,
-      policy => 'off',
+      running => true,
+      policy => 'on',
     },
     esxi_shell_time_out => 0,
     esxi_shell_interactive_time_out => 0,


### PR DESCRIPTION
Enabled SSH on all ESXi servers in the cluster which is required by the VxOS gateway to collect the logs for the SDC communication.