### PR TITLE
VXFM-6963 Skip NVDIMM configuration where NVDIMMs are missing on the server

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -226,7 +226,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
     # PCI passthrough can be enabled after VM is created because vm_host is required for this process
     configure_pci_passthru
 
-    if resource[:enable_nvdimm]
+    if resource[:enable_nvdimm] && resource[:enable_nvdimm] == true
       configure_nvdimm
     end
 

--- a/lib/puppet/type/vc_vm.rb
+++ b/lib/puppet/type/vc_vm.rb
@@ -179,10 +179,10 @@ Puppet::Type.newtype(:vc_vm) do
     defaultto(:false)
   end
 
-  newparam(:enable_nvdimm ) do
+  newparam(:enable_nvdimm, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc 'Enable nvdimm device from host'
-    newvalues(:true, :false)
-    defaultto(:false)
+    newvalues(true, false)
+    defaultto(false)
   end
 
   newparam(:guest_type) do

--- a/spec/unit/puppet/provider/vc_vm/vc_vm_spec.rb
+++ b/spec/unit/puppet/provider/vc_vm/vc_vm_spec.rb
@@ -179,7 +179,6 @@ describe "vm create and clone behavior testing" do
       provider.expects(:cdrom_iso).returns(mock("cdrom_object"))
       provider.expects(:iso_file).returns(mock("cdrom_object"))
       provider.expects(:configure_pci_passthru)
-      provider.expects(:configure_nvdimm)
       provider.initialize_property_flush
     end
 
@@ -195,7 +194,16 @@ describe "vm create and clone behavior testing" do
 
       provider.create
     end
- 
+
+    it "should clone vm when nvdimm is enabled" do
+      provider.resource[:template] = "mock_template"
+      provider.resource[:enable_nvdimm] = true
+      provider.expects(:configure_nvdimm)
+      provider.expects(:clone_vm)
+
+      provider.create
+    end
+
     it "should deploy ovf if value of operation is deploy as ovf_url provided" do	    
       provider.resource[:ovf_url] = "http://test/test.ovf"
       provider.resource[:power_state] = "poweredOn"


### PR DESCRIPTION
validation check was looking for the existence of flag `enable_nvdimm` in the resources. This flag is passed in all the cases with value as `false`. We need to perform the operation only when the value of the flag is `true`