### PR TITLE
VXFM-8788: Using parenthesis in Distributed Virtual Port group settings that get applied to VMs fail

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -1182,7 +1182,7 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
   # Returns the portgroup name and VDS name as a list
   # The first element is the portgroup name and the second is the VDS name
   def network_names(net)
-    net["portgroup"].match(/^(\b.*?)\ \((.*?)\)$/)
+    net["portgroup"].match(/^(\b.*\(*\)*\{*\}*\[*\]*?)\ \((.*?)\)$/)
     [$1,$2]
   end
 


### PR DESCRIPTION
Modified code to accept parenthesis in Distributed Virtual Port group settings